### PR TITLE
fix(prompts): bind prompts to the serving McpServer shell

### DIFF
--- a/server/src/modules/prompts/index.ts
+++ b/server/src/modules/prompts/index.ts
@@ -119,11 +119,14 @@ export class PromptAssetManager {
   /**
    * Register prompts with MCP server
    */
-  async registerAllPrompts(prompts: ConvertedPrompt[]): Promise<number> {
+  async registerAllPrompts(
+    prompts: ConvertedPrompt[],
+    target?: Parameters<PromptRegistry['registerAllPrompts']>[1]
+  ): Promise<number> {
     if (!this.registry) {
       throw new Error('MCP server not provided - cannot register prompts');
     }
-    return this.registry.registerAllPrompts(prompts);
+    return this.registry.registerAllPrompts(prompts, target);
   }
 
   /**

--- a/server/src/modules/prompts/registry.ts
+++ b/server/src/modules/prompts/registry.ts
@@ -28,8 +28,22 @@ export class PromptRegistry {
   private mcpServer: PromptRegistryServer;
   private conversationStore: ConversationStore;
   // templateProcessor removed - functionality consolidated into UnifiedPromptProcessor
-  private registeredPromptIds = new Set<string>(); // Track registered prompt IDs to prevent duplicates
+  // Dedup is per serving unit: `createMcpServerFactory` builds one `McpServer`
+  // shell per STDIO connection / HTTP request, so the same prompt legitimately
+  // registers once on each. A single flat Set would let the first unit's IDs
+  // suppress registration on every later one.
+  private registeredPromptIds = new WeakMap<object, Set<string>>();
   private exportedPromptIds = new Set<string>(); // Prompt IDs exported as skills (auto-deregistered)
+
+  /** Registered-ID set for one serving unit, created on first sight. */
+  private registeredIdsFor(target: PromptRegistryServer): Set<string> {
+    let ids = this.registeredPromptIds.get(target);
+    if (!ids) {
+      ids = new Set<string>();
+      this.registeredPromptIds.set(target, ids);
+    }
+    return ids;
+  }
 
   /**
    * Direct template processing method (minimal implementation)
@@ -68,9 +82,13 @@ export class PromptRegistry {
    * Register individual prompts using MCP SDK registerPrompt API
    * This implements the standard MCP prompts protocol using the high-level API
    */
-  private registerIndividualPrompts(prompts: ConvertedPrompt[]): void {
+  private registerIndividualPrompts(
+    prompts: ConvertedPrompt[],
+    target: PromptRegistryServer = this.mcpServer
+  ): void {
     try {
       this.logger.info('Registering individual prompts with MCP SDK...');
+      const registeredIds = this.registeredIdsFor(target);
       let registeredCount = 0;
 
       for (const prompt of prompts) {
@@ -88,7 +106,7 @@ export class PromptRegistry {
         }
 
         // Skip if already registered (deduplication guard)
-        if (this.registeredPromptIds.has(prompt.id)) {
+        if (registeredIds.has(prompt.id)) {
           this.logger.debug(`Skipping already registered prompt: ${prompt.id}`);
           continue;
         }
@@ -105,7 +123,7 @@ export class PromptRegistry {
         // Register the prompt using the correct MCP SDK API with error recovery
         // Use prompt.id for all MCP registration (slug-based, no spaces)
         try {
-          this.mcpServer.registerPrompt(
+          target.registerPrompt(
             prompt.id,
             {
               title: prompt.id,
@@ -119,7 +137,7 @@ export class PromptRegistry {
           );
 
           // Track the registered prompt
-          this.registeredPromptIds.add(prompt.id);
+          registeredIds.add(prompt.id);
           registeredCount++;
           this.logger.debug(`Registered prompt: ${prompt.id}`);
         } catch (error: any) {
@@ -128,7 +146,7 @@ export class PromptRegistry {
             this.logger.warn(
               `Prompt '${prompt.id}' already registered in MCP SDK, skipping re-registration`
             );
-            this.registeredPromptIds.add(prompt.id); // Track it anyway
+            registeredIds.add(prompt.id); // Track it anyway
             continue;
           } else {
             // Re-throw other errors
@@ -224,12 +242,15 @@ export class PromptRegistry {
   /**
    * Register all prompts with the MCP server using proper MCP protocol
    */
-  async registerAllPrompts(prompts: ConvertedPrompt[]): Promise<number> {
+  async registerAllPrompts(
+    prompts: ConvertedPrompt[],
+    target: PromptRegistryServer = this.mcpServer
+  ): Promise<number> {
     try {
       this.logger.info(`Registering ${prompts.length} prompts with MCP SDK registerPrompt API...`);
 
       // Register individual prompts using the correct MCP SDK API
-      this.registerIndividualPrompts(prompts);
+      this.registerIndividualPrompts(prompts, target);
 
       this.logger.info(`Successfully registered ${prompts.length} prompts with MCP SDK`);
       return prompts.length;

--- a/server/src/runtime/application.ts
+++ b/server/src/runtime/application.ts
@@ -409,6 +409,13 @@ export class Application {
       // per-call `extra` the rest of the server reads does not exist yet.
       await this.mcpToolsManager.registerAllTools(server, resolveServingUnitScope(ctx));
       this.registerMcpResources(server);
+      // Prompts are a per-unit binding too. The registry otherwise only ever
+      // touches the shell built during module init, which no client connects
+      // to — that is what made `prompts/list` come back empty on a live STDIO
+      // connection while the log reported the prompts as registered.
+      if (this.promptManager && this._convertedPrompts.length > 0) {
+        await this.promptManager.registerAllPrompts(this._convertedPrompts, server);
+      }
       return server;
     };
   }
@@ -925,7 +932,12 @@ export class Application {
         }
 
         if (this.mcpServer) {
-          const count = await this.promptManager.registerAllPrompts(this._convertedPrompts);
+          // Same reason as the factory: re-register onto the serving shell, not
+          // the module-init one, or a reload silently drops the new prompts.
+          const count = await this.promptManager.registerAllPrompts(
+            this._convertedPrompts,
+            this.mcpServer
+          );
           this.logger.info(`🔁 Re-registered ${count} prompts after hot reload.`);
           await this.promptManager.notifyPromptsListChanged();
         }


### PR DESCRIPTION
## Problem

`prompts/list` returns an empty list on a live connection, and `prompts/get` fails with `-32602`, while the server log reports the prompts as successfully registered:

```
[INFO] Registering 68 prompts with MCP SDK registerPrompt API...
[INFO] Successfully registered 63 of 68 prompts with MCP SDK
```

Client side, against `main` (8c791695), over STDIO:

```
--> {"method":"prompts/list"}
<-- {"result":{"prompts":[]}}

--> {"method":"prompts/get","params":{"name":"<a registered id>"}}
<-- {"error":{"code":-32602,"message":"Prompt <a registered id> not found"}}
```

## Cause

The 2026-07-28 protocol revision removed protocol sessions, so a fresh `McpServer` shell is now constructed per serving unit — one per STDIO connection, one per HTTP request. `createMcpServerFactory` rebinds tools and resources onto that shell:

```ts
await this.mcpToolsManager.registerAllTools(server, resolveServingUnitScope(ctx));
this.registerMcpResources(server);
return server;
```

Prompts were never migrated to that per-unit binding. `PromptRegistry` still holds the shell it was handed during module init (`loadAndProcessData` passes `this.mcpServer` at construction), and `createStdioServerFactory` later *replaces* `this.mcpServer` with a new shell. So `registerPrompt` lands on an object no client is ever connected to.

That explains the split symptom: tools work, prompts don't.

## Fix

- `registerAllPrompts` / `registerIndividualPrompts` take an optional target shell, defaulting to the constructor one — no behavior change for existing callers.
- `createMcpServerFactory` binds prompts alongside tools and resources.
- The hot-reload path targets the serving shell too. It had the same defect, so reloaded prompts were silently dropped.
- The dedup guard becomes a `WeakMap<server, Set<id>>`. This one matters: per-unit binding means the same prompt must legitimately register once on *each* shell, and the previous flat `Set` would have let the first unit's IDs suppress registration on every later one — turning the bug into "only the first connection gets prompts" instead of fixing it.

## Verification

Against a STDIO client on the patched build:

```
prompts/list -> 63 prompts  ["antonomase_01_recherche_initiale", ...]
prompts/get  -> OK, 1 message
```

63 of 68 is correct here: 4 prompts carry `registerWithMcp: false` and 1 is exported as a skill via `skills-sync.yaml`.

`npm run typecheck` is clean. `npm run test:unit` gives 167/168 suites, 2005/2007 tests — identical to a clean `main`; the one failing suite (`shell-verify-executor`) fails the same way before this change.

No regression test is included: there is no existing unit coverage for `PromptRegistry`, and I did not want to guess at the shape you would want for a per-serving-unit binding test. Happy to add one if you tell me where it should live.