### PR TITLE
fix(prompts): bind prompts per serving unit, resolve content at call time

### DIFF
--- a/server/scripts/verify-mcp-surface.mjs
+++ b/server/scripts/verify-mcp-surface.mjs
@@ -428,6 +428,73 @@ async function runSurfaceChecks(baseUrl) {
     const verdict = check.expect(text);
     record(check.label, verdict === true, verdict === true ? `${text.length} chars` : verdict);
   }
+
+  await checkPromptProtocolSurface(client);
+}
+
+/**
+ * The native prompt primitives, reached as a client reaches them.
+ *
+ * Every check above travels through `tools/call`, and the tool layer reads an
+ * in-process array rather than anything bound to the serving `McpServer`. That
+ * is a different object graph from the one `prompts/list` answers out of, so a
+ * fully dead prompt surface — `prompts/list` returning `[]` and `prompts/get`
+ * answering -32602 on every id — scored a clean run here while the two tool
+ * listings agreed with each other perfectly. It shipped in 4.0.0 that way.
+ *
+ * Falsifiable the same way the tool checks are: the ids are compared as a SET
+ * against the catalogue the tool layer reports, so this passes only when the two
+ * independent renderings agree. A count alone is satisfied by two catalogues
+ * that disagree about every entry.
+ */
+function judgePromptProtocolListing(listed, viaTool) {
+  if (listed.length === 0) return 'protocol surface enumerates no prompts';
+  if (viaTool.length === 0) return 'no tool listing to compare against';
+  // Registration legitimately drops prompts the tool layer still lists —
+  // `registerWithMcp: false` and ids exported as client skills — so the
+  // protocol set is a SUBSET, not an equal set. Anything it lists that the tool
+  // layer does not is a real divergence.
+  const catalogue = new Set(viaTool);
+  const unknown = listed.filter((id) => !catalogue.has(id));
+  if (unknown.length > 0) {
+    return `lists ${unknown.length} prompt(s) the tool catalogue does not, e.g. "${unknown[0]}"`;
+  }
+  return true;
+}
+
+async function checkPromptProtocolSurface(client) {
+  const response = await client.send('prompts/list', {});
+  if (response?.error?.message) {
+    record('prompts/list (protocol)', false, response.error.message.slice(0, 90));
+    return;
+  }
+
+  const listed = (response?.result?.prompts ?? []).map((prompt) => prompt.name);
+  const viaTool = parseListedPromptIds(seen.get('prompt_engine listprompts') ?? '');
+  const verdict = judgePromptProtocolListing(listed, viaTool);
+  record(
+    'prompts/list (protocol)',
+    verdict === true,
+    verdict === true ? `${listed.length} of ${viaTool.length} bound` : verdict
+  );
+  if (verdict !== true) return;
+
+  // Listing a prompt and being able to fetch it are separate bindings: the
+  // registration that populates one populates the other, but a client that can
+  // only list is still broken.
+  const target = listed[0];
+  const fetched = await client.send('prompts/get', { name: target, arguments: {} });
+  if (fetched?.error?.message) {
+    record('prompts/get (protocol)', false, `${target}: ${fetched.error.message.slice(0, 70)}`);
+    return;
+  }
+  const messages = fetched?.result?.messages ?? [];
+  const hasText = messages.some((message) => (message?.content?.text ?? '').length > 0);
+  record(
+    'prompts/get (protocol)',
+    hasText,
+    hasText ? target : `${target} returned no message text`
+  );
 }
 
 /**
@@ -605,6 +672,36 @@ function runSelfTest() {
   }
 
   seen.clear();
+
+  // The protocol check is not a TOOL_CHECKS entry — it speaks `prompts/list`
+  // rather than `tools/call` — so it carries its own counterexamples. The first
+  // is the exact 4.0.0 shape: every tool check green, the native surface empty.
+  const protocolCounterexamples = [
+    { label: 'empty protocol listing', listed: [], viaTool: ['action_plan'] },
+    {
+      label: 'protocol lists an id the tool catalogue does not',
+      listed: ['action_plan', 'ghost_prompt'],
+      viaTool: ['action_plan'],
+    },
+  ];
+  for (const { label, listed, viaTool } of protocolCounterexamples) {
+    const verdict = judgePromptProtocolListing(listed, viaTool);
+    const rejected = verdict !== true;
+    record(
+      `prompts/list (protocol) — rejects ${label}`,
+      rejected,
+      rejected ? verdict : 'ACCEPTED IT'
+    );
+    if (!rejected) failures += 1;
+  }
+  // And it must still accept the healthy case: a strict subset is correct, not a finding.
+  const healthy = judgePromptProtocolListing(['action_plan'], ['action_plan', 'exported_as_skill']);
+  record(
+    'prompts/list (protocol) — accepts a legitimate subset',
+    healthy === true,
+    healthy === true ? 'subset accepted' : `REJECTED IT — ${healthy}`
+  );
+  if (healthy !== true) failures += 1;
 
   // Falsifiability answers "can this check fail?"; coverage answers "is there a check at all?".
   // A registry can grow past its gate while every existing predicate stays perfectly falsifiable,

--- a/server/src/modules/prompts/index.ts
+++ b/server/src/modules/prompts/index.ts
@@ -15,7 +15,7 @@ import * as path from 'node:path';
 import { PromptConverter } from './converter.js';
 import { PromptLoader } from './loader.js';
 import { discoverPromptDirectories, buildWatchTargets } from './prompt-watch-setup.js';
-import { PromptRegistry } from './registry.js';
+import { PromptRegistry, type PromptRegistryServer } from './registry.js';
 import {
   HotReloadObserver,
   createHotReloadObserver,
@@ -117,23 +117,30 @@ export class PromptAssetManager {
   }
 
   /**
-   * Register prompts with MCP server
+   * Register prompts onto a serving MCP server shell.
+   *
+   * `target` names the shell to bind: one is built per STDIO connection and per
+   * HTTP request, so the caller that owns the serving unit passes its own.
+   * Omitting it binds the shell handed in at construction, which is only
+   * meaningful before any serving unit exists.
    */
-  async registerAllPrompts(prompts: ConvertedPrompt[]): Promise<number> {
+  async registerAllPrompts(
+    prompts: ConvertedPrompt[],
+    target?: PromptRegistryServer
+  ): Promise<number> {
     if (!this.registry) {
       throw new Error('MCP server not provided - cannot register prompts');
     }
-    return this.registry.registerAllPrompts(prompts);
+    return this.registry.registerAllPrompts(prompts, target);
   }
 
   /**
-   * Notify clients that prompt list has changed (for hot-reload)
+   * Publish the current prompt content without binding it to a shell.
+   *
+   * Load and hot reload go through here; binding is the serving unit's job.
    */
-  async notifyPromptsListChanged(): Promise<void> {
-    if (!this.registry) {
-      throw new Error('MCP server not provided - cannot send notifications');
-    }
-    await this.registry.notifyPromptsListChanged();
+  setLivePrompts(prompts: ConvertedPrompt[]): void {
+    this.registry?.setLivePrompts(prompts);
   }
 
   /**
@@ -183,21 +190,23 @@ export class PromptAssetManager {
     promptsData: PromptData[];
     categories: Category[];
     convertedPrompts: ConvertedPrompt[];
-    registeredCount: number;
+    loadedCount: number;
   }> {
     try {
       // Load and convert prompts
       const result = await this.loadAndConvertPrompts(configPath, basePath);
 
-      // Register with MCP server if available
-      let registeredCount = 0;
+      // Publish content only. Binding happens per serving unit, so registering
+      // here would target the construction-time shell that no client connects
+      // to — which is what made a loaded-but-unreachable prompt surface report
+      // itself as registered.
       if (this.registry) {
-        registeredCount = await this.registerAllPrompts(result.convertedPrompts);
+        this.setLivePrompts(result.convertedPrompts);
       } else {
         this.logger.warn('MCP server not available - skipping prompt registration');
       }
 
-      return { ...result, registeredCount };
+      return { ...result, loadedCount: result.convertedPrompts.length };
     } catch (error) {
       this.logger.error('Error initializing prompt system:', error);
       throw error;
@@ -214,7 +223,7 @@ export class PromptAssetManager {
     promptsData: PromptData[];
     categories: Category[];
     convertedPrompts: ConvertedPrompt[];
-    registeredCount: number;
+    loadedCount: number;
   }> {
     this.logger.info('Reloading prompt system...');
 

--- a/server/src/modules/prompts/registry.ts
+++ b/server/src/modules/prompts/registry.ts
@@ -17,19 +17,42 @@ import { isChainPrompt } from '#shared/utils/chainUtils.js';
 // TemplateProcessor functionality consolidated into UnifiedPromptProcessor
 
 /**
- * Prompt Registry class
+ * The slice of `McpServer` this module binds against.
+ *
+ * Exported because callers hand a specific serving shell to `registerAllPrompts`
+ * and need to name its type without reaching through `Parameters<>`.
  */
-type PromptRegistryServer = Pick<McpServer, 'registerPrompt'> & {
-  notification?: (notification: { method: string; params?: unknown }) => void;
-};
+export type PromptRegistryServer = Pick<McpServer, 'registerPrompt'>;
 
+/**
+ * Prompt Registry class
+ *
+ * Holds two pieces of state with different lifetimes, and the distinction is the
+ * whole design:
+ *
+ * - **Binding** is per serving unit. Protocol revision 2026-07-28 removed
+ *   protocol sessions, so `createMcpServerFactory` builds a fresh `McpServer`
+ *   per STDIO connection and per HTTP request. Each shell needs its own
+ *   `registerPrompt` calls, tracked in `registeredPromptIds`.
+ * - **Content** is one live singleton. `livePrompts` is replaced wholesale on
+ *   every load and hot reload, and handlers resolve through it at call time
+ *   rather than closing over the prompt they were registered with.
+ *
+ * Keeping content out of the closure is what makes an edited prompt take effect
+ * without re-registration — which the SDK rejects anyway once an id is bound.
+ */
 export class PromptRegistry {
   private logger: Logger;
   private mcpServer: PromptRegistryServer;
   private conversationStore: ConversationStore;
   // templateProcessor removed - functionality consolidated into UnifiedPromptProcessor
-  private registeredPromptIds = new Set<string>(); // Track registered prompt IDs to prevent duplicates
+  // Dedup is per serving unit: the same prompt legitimately registers once on
+  // each shell, so a single flat Set would let the first unit's ids suppress
+  // registration on every later one.
+  private registeredPromptIds = new WeakMap<PromptRegistryServer, Set<string>>();
   private exportedPromptIds = new Set<string>(); // Prompt IDs exported as skills (auto-deregistered)
+  /** Current content for every loaded prompt, keyed by id. Replaced on reload. */
+  private livePrompts = new Map<string, ConvertedPrompt>();
 
   /**
    * Direct template processing method (minimal implementation)
@@ -55,6 +78,38 @@ export class PromptRegistry {
     // templateProcessor removed - functionality consolidated into UnifiedPromptProcessor
   }
 
+  /** Registered-id set for one serving unit, created on first sight. */
+  private registeredIdsFor(target: PromptRegistryServer): Set<string> {
+    let ids = this.registeredPromptIds.get(target);
+    if (!ids) {
+      ids = new Set<string>();
+      this.registeredPromptIds.set(target, ids);
+    }
+    return ids;
+  }
+
+  /**
+   * Replace the live content every registered handler resolves through.
+   *
+   * Called on load and on every hot reload. Handlers registered against any
+   * shell — including ones bound before this call — serve the new content from
+   * their next invocation, which is why an edited prompt needs no re-binding.
+   */
+  setLivePrompts(prompts: ConvertedPrompt[]): void {
+    this.livePrompts = new Map(prompts.map((prompt) => [prompt.id, prompt]));
+  }
+
+  /**
+   * Current content for a prompt id.
+   *
+   * Falls back to the definition captured at registration when the id is absent
+   * from the live map — a prompt deleted from disk keeps answering with its last
+   * known content rather than throwing at a client that still has it listed.
+   */
+  private resolveLivePrompt(registered: ConvertedPrompt): ConvertedPrompt {
+    return this.livePrompts.get(registered.id) ?? registered;
+  }
+
   /**
    * Set prompt IDs that have been exported as client skills via skills-sync.
    * Exported prompts are auto-deregistered from MCP to avoid duplication.
@@ -68,9 +123,13 @@ export class PromptRegistry {
    * Register individual prompts using MCP SDK registerPrompt API
    * This implements the standard MCP prompts protocol using the high-level API
    */
-  private registerIndividualPrompts(prompts: ConvertedPrompt[]): void {
+  private registerIndividualPrompts(
+    prompts: ConvertedPrompt[],
+    target: PromptRegistryServer
+  ): number {
     try {
       this.logger.info('Registering individual prompts with MCP SDK...');
+      const registeredIds = this.registeredIdsFor(target);
       let registeredCount = 0;
 
       for (const prompt of prompts) {
@@ -87,8 +146,8 @@ export class PromptRegistry {
           continue;
         }
 
-        // Skip if already registered (deduplication guard)
-        if (this.registeredPromptIds.has(prompt.id)) {
+        // Skip if already registered on THIS shell (deduplication guard)
+        if (registeredIds.has(prompt.id)) {
           this.logger.debug(`Skipping already registered prompt: ${prompt.id}`);
           continue;
         }
@@ -105,7 +164,7 @@ export class PromptRegistry {
         // Register the prompt using the correct MCP SDK API with error recovery
         // Use prompt.id for all MCP registration (slug-based, no spaces)
         try {
-          this.mcpServer.registerPrompt(
+          target.registerPrompt(
             prompt.id,
             {
               title: prompt.id,
@@ -114,12 +173,14 @@ export class PromptRegistry {
             },
             async (args: any) => {
               this.logger.debug(`Executing prompt '${prompt.id}' with args:`, args);
-              return await this.executePromptLogic(prompt, args || {});
+              // Resolve content now, not at registration: a hot reload replaces
+              // the live map, and this closure outlives it.
+              return await this.executePromptLogic(this.resolveLivePrompt(prompt), args || {});
             }
           );
 
           // Track the registered prompt
-          this.registeredPromptIds.add(prompt.id);
+          registeredIds.add(prompt.id);
           registeredCount++;
           this.logger.debug(`Registered prompt: ${prompt.id}`);
         } catch (error: any) {
@@ -128,7 +189,7 @@ export class PromptRegistry {
             this.logger.warn(
               `Prompt '${prompt.id}' already registered in MCP SDK, skipping re-registration`
             );
-            this.registeredPromptIds.add(prompt.id); // Track it anyway
+            registeredIds.add(prompt.id); // Track it anyway
             continue;
           } else {
             // Re-throw other errors
@@ -141,6 +202,7 @@ export class PromptRegistry {
       this.logger.info(
         `Successfully registered ${registeredCount} of ${prompts.length} prompts with MCP SDK`
       );
+      return registeredCount;
     } catch (error) {
       this.logger.error(
         'Error registering individual prompts:',
@@ -224,40 +286,32 @@ export class PromptRegistry {
   /**
    * Register all prompts with the MCP server using proper MCP protocol
    */
-  async registerAllPrompts(prompts: ConvertedPrompt[]): Promise<number> {
+  async registerAllPrompts(
+    prompts: ConvertedPrompt[],
+    target: PromptRegistryServer = this.mcpServer
+  ): Promise<number> {
     try {
       this.logger.info(`Registering ${prompts.length} prompts with MCP SDK registerPrompt API...`);
 
-      // Register individual prompts using the correct MCP SDK API
-      this.registerIndividualPrompts(prompts);
+      // Content first: handlers bound below resolve through the live map, and
+      // handlers bound on earlier shells pick the new content up from here too.
+      this.setLivePrompts(prompts);
 
-      this.logger.info(`Successfully registered ${prompts.length} prompts with MCP SDK`);
-      return prompts.length;
+      // Returns what actually bound, which is lower than `prompts.length`
+      // whenever a prompt opts out or is exported as a skill. Reporting the
+      // input length instead is what let a fully dead prompt surface log as a
+      // success.
+      return this.registerIndividualPrompts(prompts, target);
     } catch (error) {
       this.logger.error(`Error registering prompts:`, error);
       throw error;
     }
   }
 
-  /**
-   * Send list_changed notification to clients (for hot-reload)
-   * This is the proper MCP way to notify clients about prompt updates
-   */
-  async notifyPromptsListChanged(): Promise<void> {
-    try {
-      // Send MCP notification that prompt list has changed
-      if (this.mcpServer && typeof this.mcpServer.notification === 'function') {
-        this.mcpServer.notification({
-          method: 'notifications/prompts/list_changed',
-        });
-        this.logger.info('✅ Sent prompts/list_changed notification to clients');
-      } else {
-        this.logger.debug("MCP server doesn't support notifications");
-      }
-    } catch (error) {
-      this.logger.warn('Could not send prompts/list_changed notification:', error);
-    }
-  }
+  // Announcing the list change is NOT this class's job: the registry only ever
+  // holds the shell it was constructed with, which no client connects to once
+  // binding became per serving unit. `runtime/list-change-notifier.ts` owns the
+  // transport choice for all three list kinds — see `publishPromptsChanged`.
 
   // Note: MCP SDK doesn't provide prompt unregistration
   // Hot-reload is handled through list_changed notifications to clients

--- a/server/src/runtime/application.ts
+++ b/server/src/runtime/application.ts
@@ -17,7 +17,11 @@ import { loadPromptData } from './data-loader.js';
 import { buildFrameworkAuxiliaryReloadConfig } from './framework-hot-reload.js';
 import { buildGateAuxiliaryReloadConfig } from './gate-hot-reload.js';
 import { buildHealthReport } from './health.js';
-import { publishResourcesChanged, publishToolsChanged } from './list-change-notifier.js';
+import {
+  publishPromptsChanged,
+  publishResourcesChanged,
+  publishToolsChanged,
+} from './list-change-notifier.js';
 import { initializeModules } from './module-initializer.js';
 import { resolveRuntimeLaunchOptions, RuntimeLaunchOptions } from './options.js';
 import { buildResourceChangeTrackerAuxiliaryReloadConfig } from './resource-change-tracking.js';
@@ -409,6 +413,13 @@ export class Application {
       // per-call `extra` the rest of the server reads does not exist yet.
       await this.mcpToolsManager.registerAllTools(server, resolveServingUnitScope(ctx));
       this.registerMcpResources(server);
+      // Prompts bind per unit for the same reason tools do. They were the one
+      // primitive left on the construction-time shell, so `prompts/list` came
+      // back empty on a live connection while startup logged them as
+      // registered.
+      if (this._convertedPrompts.length > 0) {
+        await this.promptManager.registerAllPrompts(this._convertedPrompts, server);
+      }
       return server;
     };
   }
@@ -807,7 +818,7 @@ export class Application {
 
       // Step 4: Notify MCP clients that the prompt list has changed (proper hot-reload)
       // This follows MCP protocol - clients will re-query the server for the updated list
-      await this.promptManager.notifyPromptsListChanged();
+      publishPromptsChanged(this.listChangeTargets());
       this.logger.info('✅ Prompts list_changed notification sent to MCP clients.');
 
       // Step 5:  - Workflow registration removed
@@ -924,11 +935,16 @@ export class Application {
           this.apiRouter.updateData(this._promptsData, this._categories, this._convertedPrompts);
         }
 
-        if (this.mcpServer) {
-          const count = await this.promptManager.registerAllPrompts(this._convertedPrompts);
-          this.logger.info(`🔁 Re-registered ${count} prompts after hot reload.`);
-          await this.promptManager.notifyPromptsListChanged();
-        }
+        // Content refresh alone updates every already-bound handler, on every
+        // shell, because handlers resolve through the live map at call time.
+        // Re-binding still matters for ids that did not exist when the serving
+        // shell was built; the dedup guard makes it a no-op for the rest.
+        const count = await this.promptManager.registerAllPrompts(
+          this._convertedPrompts,
+          this.mcpServer
+        );
+        this.logger.info(`🔁 Refreshed prompts after hot reload (${count} newly bound).`);
+        publishPromptsChanged(this.listChangeTargets());
 
         // Prompt resources project `_convertedPrompts`, so a reload changes the
         // resource list too. Prompts were already announced above; resources

--- a/server/src/runtime/data-loader.ts
+++ b/server/src/runtime/data-loader.ts
@@ -156,10 +156,13 @@ export async function loadPromptData(params: PromptDataLoadParams): Promise<Prom
     promptManager.setExportedPromptIds(exportedPromptIds);
   }
 
-  // Register prompts with MCP server
-  await promptManager.registerAllPrompts(convertedPrompts);
+  // Publish content, do not bind. Binding is per serving unit — one shell per
+  // STDIO connection and per HTTP request — so `createMcpServerFactory` owns it.
+  // Registering here would target the construction-time shell no client attaches
+  // to, and report success for a prompt surface that answers nothing.
+  promptManager.setLivePrompts(convertedPrompts);
   if (!isQuiet) {
-    logger.info('🔄 Prompts registered with MCP server');
+    logger.info(`🔄 ${convertedPrompts.length} prompts published to the MCP prompt registry`);
   }
 
   return {

--- a/server/src/runtime/list-change-notifier.ts
+++ b/server/src/runtime/list-change-notifier.ts
@@ -29,12 +29,14 @@ import { notifyResourcesChanged } from '#modules/resources/index.js';
 export interface ListChangePublisher {
   toolsChanged: () => void;
   resourcesChanged: () => void;
+  promptsChanged: () => void;
 }
 
-/** The instance STDIO pinned, narrowed to the two pushes used here. */
+/** The instance STDIO pinned, narrowed to the three pushes used here. */
 export interface ListChangeServer {
   sendToolListChanged: () => void;
   sendResourceListChanged: () => void;
+  sendPromptListChanged: () => void;
 }
 
 export interface ListChangeTargets {
@@ -63,6 +65,29 @@ export function publishToolsChanged(targets: ListChangeTargets): void {
     logger.debug('[ListChange] Published tools/list change over STDIO');
   } catch (error) {
     logger.warn('[ListChange] Failed to publish tools/list change:', error);
+  }
+}
+
+/**
+ * Announce that the prompt list changed.
+ *
+ * Same transport choice as the tools push. This lives here rather than on
+ * `PromptRegistry` because the registry holds only the shell it was constructed
+ * with, and per-serving-unit binding means that shell has no client attached —
+ * a notification sent from it reached nobody on either transport.
+ */
+export function publishPromptsChanged(targets: ListChangeTargets): void {
+  const { httpPublisher, pinnedServer, logger } = targets;
+  try {
+    if (httpPublisher != null) {
+      httpPublisher.promptsChanged();
+      logger.debug('[ListChange] Published prompts/list change over HTTP');
+      return;
+    }
+    pinnedServer.sendPromptListChanged();
+    logger.debug('[ListChange] Published prompts/list change over STDIO');
+  } catch (error) {
+    logger.warn('[ListChange] Failed to publish prompts/list change:', error);
   }
 }
 

--- a/server/tests/unit/prompts/registry-serving-unit-binding.test.ts
+++ b/server/tests/unit/prompts/registry-serving-unit-binding.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, jest, test } from '@jest/globals';
+
+import { PromptRegistry } from '../../../src/modules/prompts/registry.js';
+
+import type { ConvertedPrompt } from '../../../src/engine/execution/types.js';
+import type { PromptRegistryServer } from '../../../src/modules/prompts/registry.js';
+
+/**
+ * Protocol revision 2026-07-28 removed protocol sessions, so a fresh `McpServer`
+ * is built per STDIO connection and per HTTP request. These tests pin the two
+ * consequences that made `prompts/list` come back empty on a live connection
+ * while startup logged the prompts as registered:
+ *
+ *  - binding must land on the shell the caller names, once per shell;
+ *  - content must resolve when the handler runs, not when it was registered.
+ */
+
+type Handler = (args: Record<string, string>) => Promise<{
+  messages: { role: string; content: { type: string; text: string } }[];
+}>;
+
+/** Stand-in for one serving unit. Records what was bound to it. */
+function makeShell() {
+  const handlers = new Map<string, Handler>();
+  return {
+    registerPrompt: jest.fn((id: string, _config: unknown, handler: Handler) => {
+      if (handlers.has(id)) throw new Error(`Prompt ${id} is already registered`);
+      handlers.set(id, handler);
+    }),
+    handlers,
+  };
+}
+
+function makePrompt(overrides: Partial<ConvertedPrompt> = {}): ConvertedPrompt {
+  return {
+    id: 'test_default',
+    name: 'Test Default',
+    description: 'A prompt',
+    category: 'examples',
+    userMessageTemplate: 'original body',
+    arguments: [],
+    ...overrides,
+  } as ConvertedPrompt;
+}
+
+/**
+ * The fake carries a `handlers` map the real shell has no notion of, and its
+ * `registerPrompt` is typed against this file's simplified `Handler`. Narrowing
+ * it at the boundary keeps the extra surface available to assertions without
+ * claiming the fake IS an `McpServer`.
+ */
+function asShell(shell: ReturnType<typeof makeShell>): PromptRegistryServer {
+  return shell as unknown as PromptRegistryServer;
+}
+
+const silentLogger = {
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+} as never;
+
+const conversationStore = {
+  getPreviousMessage: () => '',
+  addToConversationHistory: () => undefined,
+} as never;
+
+function makeRegistry(constructionShell: ReturnType<typeof makeShell>) {
+  return new PromptRegistry(silentLogger, asShell(constructionShell), conversationStore);
+}
+
+async function textFrom(shell: ReturnType<typeof makeShell>, id: string): Promise<string> {
+  const handler = shell.handlers.get(id);
+  if (!handler) throw new Error(`no handler bound for ${id}`);
+  const result = await handler({});
+  return result.messages.map((m) => m.content.text).join('\n');
+}
+
+describe('PromptRegistry serving-unit binding', () => {
+  test('binds to the target shell, not the one held since construction', async () => {
+    const construction = makeShell();
+    const serving = makeShell();
+    const registry = makeRegistry(construction);
+
+    await registry.registerAllPrompts([makePrompt()], asShell(serving));
+
+    expect(serving.handlers.has('test_default')).toBe(true);
+    expect(construction.registerPrompt).not.toHaveBeenCalled();
+  });
+
+  test('registers the same prompt on every serving unit', async () => {
+    const registry = makeRegistry(makeShell());
+    const first = makeShell();
+    const second = makeShell();
+
+    await registry.registerAllPrompts([makePrompt()], asShell(first));
+    await registry.registerAllPrompts([makePrompt()], asShell(second));
+
+    // A single flat dedup Set would let the first unit's ids suppress the
+    // second, turning the defect into "only the first connection gets prompts".
+    expect(first.handlers.has('test_default')).toBe(true);
+    expect(second.handlers.has('test_default')).toBe(true);
+  });
+
+  test('does not re-register the same prompt on one shell', async () => {
+    const registry = makeRegistry(makeShell());
+    const serving = makeShell();
+
+    await registry.registerAllPrompts([makePrompt()], asShell(serving));
+    await registry.registerAllPrompts([makePrompt()], asShell(serving));
+
+    // The SDK throws on a duplicate id; the guard is what keeps a reload from
+    // hitting that path.
+    expect(serving.registerPrompt).toHaveBeenCalledTimes(1);
+  });
+
+  test('reports the count that actually bound, not the count offered', async () => {
+    const registry = makeRegistry(makeShell());
+    const serving = makeShell();
+
+    const count = await registry.registerAllPrompts(
+      [makePrompt(), makePrompt({ id: 'opted_out', registerWithMcp: false })],
+      asShell(serving)
+    );
+
+    expect(count).toBe(1);
+  });
+
+  test('a handler bound before a reload serves the reloaded content', async () => {
+    const registry = makeRegistry(makeShell());
+    const serving = makeShell();
+
+    await registry.registerAllPrompts([makePrompt()], asShell(serving));
+    expect(await textFrom(serving, 'test_default')).toContain('original body');
+
+    // What a hot reload does: same ids, new content, no re-binding possible
+    // because the SDK rejects a duplicate registration.
+    registry.setLivePrompts([makePrompt({ userMessageTemplate: 'edited body' })]);
+
+    expect(await textFrom(serving, 'test_default')).toContain('edited body');
+  });
+
+  test('keeps serving last known content when a prompt leaves the live set', async () => {
+    const registry = makeRegistry(makeShell());
+    const serving = makeShell();
+
+    await registry.registerAllPrompts([makePrompt()], asShell(serving));
+    registry.setLivePrompts([]);
+
+    // The id stays bound on the shell for the connection's lifetime, so the
+    // handler must answer rather than throw at a client that still lists it.
+    expect(await textFrom(serving, 'test_default')).toContain('original body');
+  });
+});

--- a/server/tests/unit/runtime/list-change-notifier.test.ts
+++ b/server/tests/unit/runtime/list-change-notifier.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, jest, test } from '@jest/globals';
 
 import {
+  publishPromptsChanged,
   publishResourcesChanged,
   publishToolsChanged,
 } from '../../../src/runtime/list-change-notifier.js';
@@ -34,17 +35,22 @@ function makeServer(): ListChangeServer {
   return {
     sendToolListChanged: jest.fn(),
     sendResourceListChanged: jest.fn(),
+    sendPromptListChanged: jest.fn(),
   };
 }
 
 function makeTargets(withHttp: boolean): {
   targets: ListChangeTargets;
   server: ListChangeServer;
-  publisher: { toolsChanged: jest.Mock; resourcesChanged: jest.Mock };
+  publisher: { toolsChanged: jest.Mock; resourcesChanged: jest.Mock; promptsChanged: jest.Mock };
   logger: Logger;
 } {
   const server = makeServer();
-  const publisher = { toolsChanged: jest.fn(), resourcesChanged: jest.fn() };
+  const publisher = {
+    toolsChanged: jest.fn(),
+    resourcesChanged: jest.fn(),
+    promptsChanged: jest.fn(),
+  };
   const logger = makeLogger();
   return {
     targets: {
@@ -133,6 +139,46 @@ describe('publishResourcesChanged', () => {
     publishToolsChanged(targets);
 
     expect(publisher.toolsChanged).toHaveBeenCalledTimes(1);
+    expect(publisher.resourcesChanged).not.toHaveBeenCalled();
+  });
+});
+
+describe('publishPromptsChanged', () => {
+  test('publishes through the HTTP notifier when HTTP is serving', () => {
+    const { targets, server, publisher } = makeTargets(true);
+
+    publishPromptsChanged(targets);
+
+    expect(publisher.promptsChanged).toHaveBeenCalledTimes(1);
+    expect(server.sendPromptListChanged).not.toHaveBeenCalled();
+  });
+
+  test('pushes from the pinned instance on the STDIO-only path', () => {
+    const { targets, server, publisher } = makeTargets(false);
+
+    publishPromptsChanged(targets);
+
+    expect(server.sendPromptListChanged).toHaveBeenCalledTimes(1);
+    expect(publisher.promptsChanged).not.toHaveBeenCalled();
+  });
+
+  test('swallows a publish failure so a hot reload cannot be aborted by it', () => {
+    const { targets, logger } = makeTargets(false);
+    (targets.pinnedServer.sendPromptListChanged as jest.Mock).mockImplementation(() => {
+      throw new Error('Connection closed');
+    });
+
+    expect(() => publishPromptsChanged(targets)).not.toThrow();
+    expect(logger.warn).toHaveBeenCalled();
+  });
+
+  test('does not fire the sibling events', () => {
+    const { targets, publisher } = makeTargets(true);
+
+    publishPromptsChanged(targets);
+
+    expect(publisher.promptsChanged).toHaveBeenCalledTimes(1);
+    expect(publisher.toolsChanged).not.toHaveBeenCalled();
     expect(publisher.resourcesChanged).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Supersedes #204, which diagnosed this correctly. @benmidsutton is co-author on the commit.

## Problem

Protocol revision 2026-07-28 removed protocol sessions, so `createMcpServerFactory` builds a fresh `McpServer` per STDIO connection and per HTTP request. Tools and resources are rebound onto that shell. Prompts were not. `PromptRegistry` kept the shell handed to it during module init, which no client connects to, so `registerPrompt` landed on a dead object.

Reproduced on v4.0.0, both transports:

```
main / STDIO   prompts/list -> 0     tools/list -> 3
main / HTTP    prompts/list -> []    tools/list -> 3
```

Startup logged `Successfully registered 63 of 68` throughout.

## Fix

The registry now holds two things with different lifetimes.

**Binding is per serving unit.** `registerAllPrompts` takes the target shell. The dedup guard is a `WeakMap<shell, Set<id>>`, because the same prompt must register once on each shell and a flat `Set` would let the first unit's ids suppress every later one. That turns the bug into "only the first connection gets prompts", which is harder to spot than an empty list.

**Content is one live map**, replaced by `setLivePrompts` on load and on every hot reload. Handlers resolve through it when they run instead of closing over the definition they were registered with, so an edited prompt takes effect without re-binding. The SDK rejects a duplicate registration anyway, so re-binding was never available as a fix.

That split lets the dead registration go. `data-loader` and `initializePromptSystem` publish content only, since binding belongs to the serving unit. `registerAllPrompts` now returns what actually bound instead of the input length.

Announcing the change moves to `runtime/list-change-notifier.ts` beside `publishToolsChanged` and `publishResourcesChanged`. The registry's own `notifyPromptsListChanged` pushed from the construction-time shell, so the notification reached nobody on either transport.

## Verification

`verify:mcp` gained a `prompts/list` and `prompts/get` protocol check. Every existing check travels through `tools/call`, and the tool layer reads an in-process array rather than anything bound to the serving shell. That is how a completely dead prompt surface scored 11/11 and shipped in 4.0.0.

Confirmed to catch its own motivating instance: against unfixed source all 11 original tool checks still pass and only the new check fails. Its counterexamples run under `--self-test`.

Six regression tests cover binding target, per-shell dedup, true count, and live content resolution. Each was confirmed to fail against the corresponding mutation (stale closure, flat Set, construction-shell binding).

| Gate | Result |
|---|---|
| `typecheck` | pass |
| `lint:ratchet` | pass, no regressions |
| `typecheck:tests:ratchet` | pass, no regressions |
| `validate:all` | 39/39 |
| `test:unit` | 192 suites, 2496 tests |
| `verify:mcp` | 14/14, both transports |

STDIO 0 to 33 prompts, HTTP empty to populated, `prompts/get` resolving on both.

## Known gap

Hot reload did not fire under STDIO in local testing. Held a connection open 200s after editing a prompt file and neither the native surface nor `prompt_engine` observed the change, while the same edit over HTTP was picked up in seconds. That behaviour predates this change and is unaffected by it. Filed separately.
