### PR TITLE
docs: queue adaptive-chain-runtime residuals plan for retirement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,6 +163,15 @@ jobs:
         working-directory: .
         run: npm --prefix server run validate:python
 
+      # CONTRIBUTING.md classifies as `docs` (scripts/classify-validation-scope.js), and the
+      # docs route skips `validate:all` entirely. Registering this check only in the suite would
+      # leave it dead on the one kind of pull request it exists to police. It runs with no
+      # node_modules on this route, which is why the script imports nothing but node: builtins.
+      - name: Validate CONTRIBUTING commands (docs route)
+        if: needs.classify.outputs.scope == 'docs'
+        working-directory: .
+        run: node server/scripts/validate-contributing.js
+
       - name: Confirm lightweight validation
         if: needs.classify.outputs.scope != 'full'
         working-directory: .

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,20 +61,20 @@ repo/
 <details>
 <summary><strong>Available Scripts</strong> (run inside <code>server/</code>)</summary>
 
-| Command                             | Description                                 |
-| ----------------------------------- | ------------------------------------------- |
-| `npm run build`                     | esbuild bundle to `dist/index.js`           |
-| `npm run typecheck`                 | Strict TypeScript checks without emit       |
-| `npm run lint` / `lint:fix`         | ESLint validation + autofix                 |
-| `npm run lint:ratchet`              | Fail if ESLint violations increased         |
-| `npm run format` / `format:fix`     | Prettier checks/auto-format                 |
-| `npm run validate:all`              | Full validation suite (deps + architecture) |
-| `npm run validate:arch`             | Dependency Cruiser architecture rules       |
-| `npm test` / `test:jest`            | Jest suite (unit + integration)             |
-| `npm run test:integration`          | Integration tests only                      |
-| `npm run test:coverage`             | Coverage report (target: >80%)              |
-| `npm run generate:contracts`        | Regenerate MCP schemas from contracts       |
-| `npm run start:stdio` / `start:sse` | Launch transports for manual testing        |
+| Command                                     | Description                                 |
+| ------------------------------------------- | ------------------------------------------- |
+| `npm run build`                             | esbuild bundle to `dist/index.js`           |
+| `npm run typecheck`                         | Strict TypeScript checks without emit       |
+| `npm run lint` / `lint:fix`                 | ESLint validation + autofix                 |
+| `npm run lint:ratchet`                      | Fail if ESLint violations increased         |
+| `npm run validate:format`                   | Prettier check on repo-level JSON/MD/YAML   |
+| `npm run validate:all`                      | Full validation suite (deps + architecture) |
+| `npm run validate:arch`                     | Dependency Cruiser architecture rules       |
+| `npm test`                                  | Unit suite only (see `test:integration`)    |
+| `npm run test:integration`                  | Integration tests only                      |
+| `npm run test:coverage`                     | Coverage report (target: >80%)              |
+| `npm run generate:contracts`                | Regenerate MCP schemas from contracts       |
+| `npm run start:stdio` / `start:development` | STDIO / Streamable HTTP for manual testing  |
 
 </details>
 
@@ -219,12 +219,12 @@ Run validations that match what you changed:
 
 | I changed...               | Run this                                                   | Required? |
 | -------------------------- | ---------------------------------------------------------- | --------- |
-| Server source code         | `npm run typecheck && npm test`                            | Yes       |
+| Server source code         | Minimum Validation below (all four)                        | Yes       |
 | Pipeline stages            | `npm test` + smoke test both transports                    | Yes       |
 | MCP tool schemas/contracts | `npm run generate:contracts && npm run validate:contracts` | Yes       |
 | A prompt or chain template | Execute via `prompt_engine`, describe results in PR        | Yes       |
 | A gate definition          | Execute via `resource_manager`, verify gate triggers       | Yes       |
-| Transport/runtime behavior | Smoke test `npm run start:stdio` and `start:sse`           | Yes       |
+| Transport/runtime behavior | Smoke test BOTH: `start:stdio` and `start:development`     | Yes       |
 | Documentation only         | Verify references against `server/dist/**`                 | Yes       |
 | Dependencies               | `npm audit` + full test suite                              | Yes       |
 
@@ -242,8 +242,12 @@ a competing path list to a hook or required workflow.
 ### Minimum Validation (before any commit)
 
 ```bash
-npm run typecheck && npm run lint:ratchet && npm test
+npm run typecheck && npm run lint:ratchet && npm run typecheck:tests:ratchet && npm run test:ci
 ```
+
+`typecheck:tests:ratchet` is not optional. `tsconfig.json` excludes `tests/`, so `npm run typecheck`
+cannot see the call sites a signature change breaks, and Jest compiles per file without checking the
+project. A test file can pass both while carrying type errors.
 
 ### Full Validation (before pushing)
 
@@ -269,6 +273,9 @@ A [PR template](.github/pull_request_template.md) auto-fills when you open a PR.
 
 1. **Focused scope** -- one concern per PR. Split large changes into reviewable chunks.
 2. **Tests** -- new behavior has tests; changed behavior has updated tests.
+   Unit tests live in `server/tests/unit/<domain>/`, integration tests in `server/tests/integration/`.
+   Run the suite with `npm test`. To run one file directly, Jest needs the ESM flag:
+   `NODE_OPTIONS="--experimental-vm-modules" npx jest tests/unit/<path>`.
 3. **Docs updated** -- code and docs ship together.
 4. **Conventional commit** -- PR title follows commit conventions (squash-merge uses it).
 5. **Validation proof** -- link test output, screenshots, or describe manual verification steps.
@@ -296,13 +303,19 @@ Commits are blocked if checks fail. Staged files may be auto-modified by formatt
 
 Runs before every `git push`:
 
-1. `npm run typecheck`
-2. `npm run lint`
-3. `npm run format`
-4. `npm run test:jest`
-5. `npm run validate:all`
+On the full route, in order:
 
-Pushes are blocked if any command fails.
+1. Type checking (`typecheck`, then `typecheck:committed`)
+2. Linting (`lint:ratchet`)
+3. Format checking
+4. Python hook validation (`validate:python`, only when `hooks/**` changed)
+5. Tests (`test:ci`)
+6. Dependency validation (`validate:arch`)
+7. Version consistency (`validate:versions`)
+8. Build
+
+Docs-only and `hooks/**`-only pushes take lighter routes. `scripts/classify-validation-scope.js`
+decides which. Pushes are blocked if any step fails.
 
 </details>
 

--- a/plans/contributing-agreement-2026-08-16-implementation-notes.md
+++ b/plans/contributing-agreement-2026-08-16-implementation-notes.md
@@ -1,7 +1,7 @@
 ---
 title: "CONTRIBUTING agreement — implementation notes"
 date: 2026-08-16
-status: active
+status: done
 tags:
   - docs
   - scripts

--- a/plans/contributing-agreement-2026-08-16-implementation-notes.md
+++ b/plans/contributing-agreement-2026-08-16-implementation-notes.md
@@ -1,0 +1,74 @@
+---
+title: "CONTRIBUTING agreement — implementation notes"
+date: 2026-08-16
+status: active
+tags:
+  - docs
+  - scripts
+  - ci
+---
+
+# Implementation Notes
+
+Plan: [`contributing-agreement-2026-08-16.md`](./contributing-agreement-2026-08-16.md)
+
+## Rulings
+
+### OQ-2 — RULED: the validator must run on the docs CI route, and must be dependency-free
+
+**Question**: is `validate:contributing` reachable on the `docs` CI route?
+
+**Answer: no, not as the plan wrote it.** Measured, not inferred:
+
+- `scripts/classify-validation-scope.js:13` lists `CONTRIBUTING.md` as a docs-scope path.
+- `.github/workflows/ci.yml:158` runs `npm run validate:all` only when `scope == 'full'`.
+- On `docs` scope the Lint & Validate job reaches "Confirm lightweight validation" and echoes a
+  pass. No document content is checked.
+
+So a CONTRIBUTING-only PR classifies as `docs`, skips `validate:all`, and the new gate never fires.
+Registering it in `run-validation-suite.js` alone would ship a gate that is dead on exactly the PRs
+it exists to police. This is the same shape as the `verify:mcp` blind spot (a gate that could not
+observe its own subject) and as the prompt-binding defect itself.
+
+**Consequences, both binding on Tier 2:**
+
+1. A CI step must run the validator when `scope == 'docs'`, in addition to its membership in
+   `validate:all` for `scope == 'full'`.
+2. `ci.yml` guards "Setup Node.js" and "Install dependencies" on `scope != 'docs'` and
+   `scope == 'full'` respectively, so **no `node_modules` exists on the docs route**. The validator
+   must therefore use zero npm dependencies and only `node:` builtins. The runner image ships Node,
+   so a dependency-free script runs without setup.
+
+This inverts the usual direction of the CLAUDE.md rule. The rule says a hook step must exist in
+`validate:all` first, which CI runs whole. That holds. The addition here is that `validate:all` is
+not "whole" on every route, so route coverage is a separate question from suite membership.
+
+### OQ-1 — RULED: `typecheck:tests:ratchet` does not join pre-push
+
+Document it in CONTRIBUTING's Minimum Validation, leave `.husky/pre-push` alone.
+
+- It is already in `validate:all` at `run-validation-suite.js:78`, so CI catches it.
+- `pre-push` already runs 8 steps including `typecheck:committed`.
+- The failure class is caught late rather than missed, and pre-push latency is paid on every push.
+
+Revisit if a tests-ratchet failure ever reaches `main`, which would move it from late to missed.
+
+## Deviations
+
+### DEV-T2-1 — validator scope narrowed to command existence only
+
+The plan's Tier 2 already declared gate-sequence checking out of scope for v1. Restating here
+because OQ-2 adds a second reason: a dependency-free script cannot import the project's YAML or TS
+tooling, so any check needing to parse `run-validation-suite.js` semantics is out of reach on the
+docs route regardless of appetite.
+
+### DEV-T3-1 — `ci.yml` edited, which the plan did not list in scope
+
+The plan's scope named `CONTRIBUTING.md`, the new script, `package.json`, and
+`run-validation-suite.js`. OQ-2 forces a fifth file, `.github/workflows/ci.yml`. Taken as
+in-intent rather than scope creep, since the plan's acceptance criteria require the gate to catch
+its motivating instance and it cannot do that without the route step.
+
+## Discovered Unknowns
+
+None open.

--- a/plans/contributing-agreement-2026-08-16.md
+++ b/plans/contributing-agreement-2026-08-16.md
@@ -1,0 +1,125 @@
+---
+title: "CONTRIBUTING agreement with the repo — kill the drift, then gate it"
+date: 2026-08-16
+status: done
+tags:
+  - docs
+  - scripts
+  - ci
+---
+
+# CONTRIBUTING Agreement
+
+**Area**: `CONTRIBUTING.md`, `server/scripts/`, `server/package.json`, `scripts/run-validation-suite.js`
+**Work type**: bug_fix (secondary: feature)
+**Origin**: PR #204 review and the v4.0.1 release, 2026-08-16
+
+## Findings Ledger
+
+Severity is set by observed contributor failure rather than by how wrong the text reads. Three of
+six map to a specific thing that went wrong in one external contribution, which is the argument for
+the wider scope over the three-item patch.
+
+| ID  | Finding                                            | Location              | Observed failure                                                      | Status                                                                |
+| --- | -------------------------------------------------- | --------------------- | --------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| F1  | `start:sse` does not exist                         | `CONTRIBUTING.md:227` | #204 verified STDIO only; the bug was on both transports              | ✓ 2026-08-16 · both sites now name start:stdio + start:development    |
+| F2  | `npm run format` does not exist                    | commands table        | none observed                                                         | ✓ 2026-08-16 · now validate:format (format:fix was dead too, see F7b) |
+| F3  | `npm run test:jest` does not exist                 | `CONTRIBUTING.md:73`  | none observed                                                         | ✓ 2026-08-16 · alias dropped; npm test declared unit-only             |
+| F4  | Minimum Validation omits `typecheck:tests:ratchet` | `CONTRIBUTING.md:245` | 9 type errors passed both `typecheck` and Jest, 2026-08-16            | ✓ 2026-08-16 · Minimum Validation names four scripts                  |
+| F5  | No route to where tests live or the ESM flag       | `CONTRIBUTING.md:271` | #204 author had to ask where a test should go                         | ✓ 2026-08-16 · names tests/unit/<domain>/ and the ESM flag            |
+| F6  | Decision Matrix omits `lint:ratchet`               | `CONTRIBUTING.md:222` | #204 introduced 2 ratchet violations; the author ran exactly this row | ✓ 2026-08-16 · row defers to Minimum Validation                       |
+
+| F7a | Documented pre-push sequence matched no step in `.husky/pre-push` | `:296-303` | discovered during T1.6 | ✓ 2026-08-16 · replaced with the real 8-step route |
+| F7b | `format:fix` does not exist either | commands table | missed by the audit's own regex | ✓ 2026-08-16 · removed |
+
+**Root cause, common to all six.** CONTRIBUTING is unverified prose about an executable system.
+Every comparable contract here has a gate: `validate:suite-membership` for script membership,
+`validate:standards-pins` for version agreement, `validate:readme` for README structure,
+`validate:documented-options` for option coverage. Nothing reads CONTRIBUTING. The three dead
+commands rotted at three different times and none was caught.
+
+## Constraints
+
+- A hook step that CI does not run breaks the validation contract. A new check enters `validate:all`
+  first, which CI runs whole (project CLAUDE.md, Validation Gates).
+- `scripts/classify-validation-scope.js` is the changed-path SSOT. No competing path list.
+- Every validator carries a `--self-test`, and `validate:suite-membership` asserts that membership.
+- A CONTRIBUTING-only change classifies as `docs`, which routes to hygiene-only CI. See OQ-2.
+
+## Open Questions
+
+| ID   | Question                                                     | Recommendation                                                                                                                                                                                                                             | Status                                                  |
+| ---- | ------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------- |
+| OQ-1 | Does `typecheck:tests:ratchet` join `.husky/pre-push`?       | No. It is already in `validate:all` (`run-validation-suite.js:78`), pre-push already runs 8 steps including `typecheck:committed`, and the marginal catch is late rather than missed. Document it in the minimum and leave the hook alone. | RULED 2026-08-16 · no                                   |
+| OQ-2 | Is `validate:contributing` reachable on the `docs` CI route? | Must be. The gate would otherwise be absent exactly when CONTRIBUTING changes, which is the only time it matters. Highest-risk item in the plan.                                                                                           | RULED 2026-08-16 · no, hence the ci.yml docs-route step |
+
+## Tier 1 — Correct the document
+
+Mechanical. Every change is determined before editing, so it skips design gates.
+
+| Task | File                  | Change                                                                                            | Status |
+| ---- | --------------------- | ------------------------------------------------------------------------------------------------- | ------ |
+| T1.1 | `CONTRIBUTING.md:227` | `start:sse` becomes `start:development` (streamable-http)                                         | ✓      |
+| T1.2 | commands table        | `format` becomes `validate:format`                                                                | ✓      |
+| T1.3 | `CONTRIBUTING.md:73`  | Drop `test:jest`; state `npm test` is unit-only and `test:integration` is separate                | ✓      |
+| T1.4 | `CONTRIBUTING.md:245` | Add `typecheck:tests:ratchet` to Minimum Validation                                               | ✓      |
+| T1.5 | `CONTRIBUTING.md:222` | Add `lint:ratchet` to the Server source code row                                                  | ✓      |
+| T1.6 | `CONTRIBUTING.md:271` | Name `tests/unit/<domain>/`, `tests/integration/`, and `NODE_OPTIONS="--experimental-vm-modules"` | ✓      |
+
+## Tier 2 — `validate:contributing`
+
+New `server/scripts/validate-contributing.js`, modelled on the existing validators.
+
+| Task | Change                                                                                                                                                                                           | Status |
+| ---- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------ |
+| T2.1 | Extract command refs in BOTH forms: `npm run X` and bare backticked `namespace:script`. The `start:sse` reference used the bare form, so a `npm run` regex alone misses the motivating instance. | ✓      |
+| T2.2 | Assert each exists in `server/package.json` scripts; report unknowns with line numbers                                                                                                           | ✓      |
+| T2.3 | `--self-test`: reject a CONTRIBUTING containing an invented command, accept the real one                                                                                                         | ✓      |
+
+**Declared blind spot for v1**: asserting that documented gate _sequences_ match
+`run-validation-suite.js`. That needs a parse of prose intent and would produce false positives.
+Record it in the file header, per the convention in `validate-table-contracts.js`.
+
+## Tier 3 — Wire it in
+
+| Task | Change                                                                     | Status |
+| ---- | -------------------------------------------------------------------------- | ------ |
+| T3.1 | Register `validate:contributing` and `:self-test` in `server/package.json` | ✓      |
+| T3.2 | Add to `scripts/run-validation-suite.js`; rule OQ-2 first                  | ✓      |
+| T3.3 | Confirm `validate:suite-membership` passes with the new entry              | ✓      |
+| T3.4 | Record the OQ-1 ruling in the implementation notes                         | ✓      |
+
+## Tier 4 — Verify against the motivating instance
+
+| Task | Change                                                                                                  | Status |
+| ---- | ------------------------------------------------------------------------------------------------------- | ------ |
+| T4.1 | Run `validate:contributing` against `CONTRIBUTING.md` as of `f4452ced`; it must fail naming `start:sse` | ✓      |
+
+A gate that does not catch the drift that motivated it is not evidence of anything.
+
+## Acceptance
+
+| Signal                               | Pass condition                                         |
+| ------------------------------------ | ------------------------------------------------------ |
+| Dead commands                        | 0, by diffing extracted refs against `package.json`    |
+| Gate catches its motivating instance | Fails on pre-fix CONTRIBUTING naming `start:sse`       |
+| Self-test                            | Rejects an invented command, accepts the real document |
+| Suite membership                     | `validate:suite-membership` green                      |
+| Full suite                           | `validate:all` green, step count 39 to 40              |
+| No routing regression                | A CONTRIBUTING-only change still classifies as `docs`  |
+
+**Failure protocol**: a false positive on legitimate prose narrows the extraction. It does not earn
+an exception list. An exception with no exit is a permanent bypass wearing a temporary label.
+
+## Sequencing
+
+Tier 1 alone delivers user-visible value and ships first regardless, because Tier 2 without Tier 1
+leaves a red gate.
+
+## Follow-ups this surfaces but does not fix
+
+1. `README.md` and `docs/**` carry the same exposure with no equivalent check. `validate:readme`
+   asserts structure rather than command existence. If `validate:contributing` proves itself,
+   generalize the extractor into `validate:doc-commands` covering both instead of copying the script.
+2. Related open issues from the same review: #228 (`framework-compliance` ignores `exclude`) and
+   #229 (STDIO hot reload does not fire).

--- a/plans/contributing-agreement-2026-08-16.md
+++ b/plans/contributing-agreement-2026-08-16.md
@@ -1,7 +1,7 @@
 ---
 title: "CONTRIBUTING agreement with the repo — kill the drift, then gate it"
 date: 2026-08-16
-status: done
+status: reference
 tags:
   - docs
   - scripts

--- a/plans/techincal_debt/adaptive-chain-runtime-residuals-2026-08-13-implementation-notes.md
+++ b/plans/techincal_debt/adaptive-chain-runtime-residuals-2026-08-13-implementation-notes.md
@@ -1,7 +1,7 @@
 ---
 title: "Adaptive Chain Runtime residuals — implementation notes"
 date: 2026-08-13
-status: active
+status: reference
 tags: []
 ---
 
@@ -163,7 +163,23 @@ stays main-thread. No pushes without owner approval.
   verify:mcp 12/12. Final: lint:ratchet OK, validate:arch OK, targeted 198 unit + 19
   integration green.
 - Main thread: prettier'd the sweep's own doc/plan files → validate:format green.
-  Final receipt `validate:all` run in progress.
+  Final receipt: `validate:all` 39/39.
+
+## Shipped
+
+- **PR #231 MERGED 2026-08-17T04:46:45Z** (merge commit; 9 scoped commits + merge-from-main +
+  2 CI-fix commits preserved on main). CI green across Build/CLI/Test Suite/Node 22+24/Lint.
+  Two CI-only failures fixed post-push: (a) `cli/tests/integration/new-commands.test.ts`
+  encoded old rollback numbering — the standalone cli/ workspace has its OWN test surface
+  that server-side test sweeps do not cover (lesson: enumerate every workspace consuming a
+  changed module); (b) MCP tool schema snapshot (`server/tests/snapshots/mcp-input-schemas.json`
+  via capture-tool-schemas.mjs) needed regeneration for argument_updates — diff verified
+  argument_updates-only. Local checkout intentionally left on the merged feature branch:
+  returning to main would collide with a live concurrent session's uncommitted WIP.
+- Hook wart discovered during commits: pre-commit contract regeneration reads the WORKING
+  TREE contract files and re-stages all of `_generated/` whenever the generator or any
+  contract JSON is staged — defeats file-scoped commits; commit 4 needed git plumbing.
+  Candidate hook fix (not taken).
 
 ## Deviations
 

--- a/plans/techincal_debt/adaptive-chain-runtime-residuals-2026-08-13.md
+++ b/plans/techincal_debt/adaptive-chain-runtime-residuals-2026-08-13.md
@@ -1,34 +1,52 @@
 ---
 title: "Adaptive Chain Runtime — residual findings after initiative closure"
 date: 2026-08-13
-status: backlog
+status: reference
 tags: []
 ---
 
 # Adaptive Chain Runtime — residuals
 
-The initiative (P0–P7) is terminal; master plan and phase plans retired to `plans/reference/`.
-This file is the live home for every ledger row that was still OPEN at closure. Full finding
-descriptions live in the master plan's Findings Ledger
-(`plans/reference/adaptive-chain-runtime-2026-08-09.md`) — this table carries only the residue
-and its route.
+The initiative (P0–P7) is terminal; master plan and phase plans are retired
+(`plans/reference/`). This file was the live home for every ledger row still OPEN at closure.
+**The residuals sweep (2026-08-13 → 2026-08-17, PR #231, merged) closed it**: 10 of 15 rows
+fixed, 5 re-homed to live owners. This document is now a disposition record — nothing here is a
+queue. Full finding descriptions: master plan's Findings Ledger
+(`plans/reference/adaptive-chain-runtime-2026-08-09.md`). Sweep evidence:
+`adaptive-chain-runtime-residuals-2026-08-13-implementation-notes.md`.
 
-| Id     | Residue                                                                                                                                                                                                                                                                                                                                                 | Route / next actor                                                                               |
-| ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
-| P3-F5  | Each chain step still costs 2 prompt_engine calls; `declaredCostCeiling` records but nothing reduces the round-trip                                                                                                                                                                                                                                     | unowned — candidate for a future same-call capture design                                        |
-| P4-F1  | `persistSessions` catches-and-logs against the awaited-persistence posture; detector (cold-load test) landed, writer posture stands                                                                                                                                                                                                                     | cross-cutting remediation; pairs with sqlite-layer remediation plan                              |
-| P5-F6  | Gate review renders only at step 1 — DIAGNOSED 2026-08-13: code defect, frequency uninvolved. Review creation runs at stage 13 pre-advance; verdict→advance→render completes in one round trip (16→18), so step N>1 is never "current" where reviews are created. Fix: re-evaluate declared-gate review post-advance, before StepExecutionStage renders | gates hygiene backlog (gate-review lifecycle owner) — pairs with P6-F14; NOT the frequency owner |
-| P6-F10 | `patch` update rewrites the whole prompt dir; P7-F8 `tools:` drop fires against unnamed siblings                                                                                                                                                                                                                                                        | **routing awaits owner** — recommended: standalone fix(mcp-tools) follow-up                      |
-| P6-F12 | `pr_review_chain` markdown step block is unreachable prose; 4 template vars render empty                                                                                                                                                                                                                                                                | shipped-example hygiene, one resource_manager pass                                               |
-| P6-F14 | `GateSetResolver.accumulate` admits unregistered gate ids run-wide                                                                                                                                                                                                                                                                                      | gates hygiene follow-up                                                                          |
-| P6-F15 | `generate-contracts` silently skips a contract missing `metadata.artifactKind`                                                                                                                                                                                                                                                                          | candidate gate: `validate:contracts` asserts every contract yields ≥1 artifact                   |
-| P6-F16 | `patch` cannot reach nested argument descriptions; partial update does not preserve unsupplied core fields                                                                                                                                                                                                                                              | resource_manager settability follow-up (same family as P7-F8/P6-F10)                             |
-| P7-F4  | 13 of 17 prompt categories untracked → probes over `resources/prompts/` need `rg --no-ignore`                                                                                                                                                                                                                                                           | standing hazard — keep in worker briefs until categories are tracked                             |
-| P7-F8  | `tools:` dropped by both write paths; `ConvertedPrompt` has no `tools` field, so no snapshot records them                                                                                                                                                                                                                                               | resource_manager settability follow-up (fold with P6-F10 fix)                                    |
-| P7-F9  | Two unreachable `else { warn }` branches in gate/framework lifecycle processors                                                                                                                                                                                                                                                                         | delete on next touch of those processors                                                         |
-| P7-F10 | `cli-shared/version-history.ts` diverges from the server writer on numbering semantics — **flagged for sync at release**                                                                                                                                                                                                                                | **release cycle** — reconcile before or with the next release                                    |
-| P7-F11 | 4 of 286 shipped templates fail a naive dry render; future template validation must be differential                                                                                                                                                                                                                                                     | constraint on any future template-validation gate                                                |
-| P7-F12 | Create path verifies produced YAML after a version row is spent (update path fixed)                                                                                                                                                                                                                                                                     | resource_manager create-path follow-up                                                           |
-| P7-F15 | Prompt WRITE path resolves package-relative while LOADER honors `MCP_RESOURCES_PATH`                                                                                                                                                                                                                                                                    | packaged-defect initiative (`project_mcp_workspace_packaged_defect` memory)                      |
+## Fixed by the sweep (PR #231, merged 2026-08-17)
 
-Already routed elsewhere (listed for completeness, no action here): P5-F1 → subagent-delegation-contract plan (OQ-P6-6) · P7-F5 → chain-management memory (updated 2026-08-13).
+| Id     | Disposition                                                                                                                                                    |
+| ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| P5-F6  | Diagnosed (code defect, frequency uninvolved) AND fixed — post-advance declared-gate review re-evaluation; step-N>1 targeted gates now render their review     |
+| P6-F10 | Fixed — suppliedKeys write-scope narrowing; patch-only edit leaves prompt.yaml byte-identical; category change is now a true transactional MOVE (owner ruling) |
+| P6-F12 | Fixed via resource_manager (7 empty vars, not 4; missing outputMapping + bare-name refs). **Workspace-only** — `pr-review/` is gitignored (see P7-F4)          |
+| P6-F14 | Fixed — GateSetResolver Stage 1.5 existence gate (warn + drop + diagnostics; fails open pre-init)                                                              |
+| P6-F15 | Fixed — generate-contracts fails loudly on unmarked contracts; ≥1-artifact assertion; explicit artifact-less posture requires reason + closedBy                |
+| P6-F16 | Fixed — `argument_updates` merge-by-name parameter (additive contract change); preservation half had already landed at HEAD (snapshot-base merge)              |
+| P7-F8  | Data-loss half fixed — writer preserves `tools:` id list + authored category on update AND rollback. Settability half (id-string repair) → parity initiative   |
+| P7-F9  | Fixed — dead `else { warn }` branches deleted; prompt-side processor confirmed already correct                                                                 |
+| P7-F10 | Fixed — CLI rollback now mirrors go-forward numbering (bridge + restored-content-as-newest); `saveVersion` primitive was already identical; posture kept as-is |
+| P7-F12 | Fixed — create path runs `diagnosePromptWrite(null, …)` pre-write; broken template → refused, nothing written                                                  |
+
+Also fixed in-sweep (found by the settability audit, owner-ruled in): gate `activation` /
+`retry_config` / `pass_criteria` fallback-merge, and writer-side preservation of
+`severity` / `enforcementMode` / `gate_type` (+ schema-coverage guard).
+
+## Re-homed (live owners, verified to exist)
+
+| Id     | Live home                                                                                                                                                     |
+| ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| P3-F5  | `project_chain_management_tooling` memory — unowned same-call-capture design candidate                                                                        |
+| P4-F1  | `project_sqlite_layer_remediation` memory (carried debt) — its previously named route, the sqlite plan, is itself retired; the memory is the live owner       |
+| P7-F4  | `resource-manager-settability-matrix-2026-08-13.md` §Standing hazards — tracking-policy decision belongs to the settability-parity initiative                 |
+| P7-F11 | `resource-manager-settability-matrix-2026-08-13.md` §Standing hazards — differential-validation constraint; already embodied by shipped `diagnosePromptWrite` |
+| P7-F15 | `project_mcp_workspace_packaged_defect` memory (packaged-defect initiative)                                                                                   |
+
+Already routed elsewhere before the sweep (unchanged): P5-F1 → subagent-delegation-contract plan
+(OQ-P6-6) · P7-F5 → chain-management memory (updated 2026-08-13).
+
+Successor initiative seeded by the sweep: **resource_manager settability parity** —
+`resource-manager-settability-matrix-2026-08-13.md` (matrix, ranked gaps, 7-step increment
+sequence, prompt_builder bridge repair).

--- a/plans/techincal_debt/resource-manager-settability-matrix-2026-08-13.md
+++ b/plans/techincal_debt/resource-manager-settability-matrix-2026-08-13.md
@@ -272,3 +272,16 @@ Also flagged, not in the top 5 by severity but cheap to fix and cited above:
   anywhere in `src/`; (4) chain integrity is a transient, warn-only check at one prompt's own
   write time, with no standing sweep of durable chain resources and no re-check when a referenced
   prompt is later deleted.
+
+## Standing hazards absorbed from the residuals plan (re-homed 2026-08-17)
+
+- **P7-F4** — 13 of 17 prompt categories are gitignored: probes over `resources/prompts/` need
+  `rg --no-ignore`, worker briefs must carry the warning, and fixes to gitignored shipped
+  examples (e.g. the P6-F12 `pr_review_chain` repair) exist only in the local workspace and can
+  never be committed. Real fix is a tracking-policy decision (owner's call) — this initiative is
+  the natural place to make it, since settability parity is meaningless for resources git cannot
+  see.
+- **P7-F11** — 4 of 286 shipped templates fail a naive dry render, so any future bulk
+  template-validation gate must be DIFFERENTIAL (new defects block, pre-existing ones are
+  amnestied). Note the shipped `diagnosePromptWrite` design already embodies this: update mode
+  amnesties pre-existing defects, create mode (`before = null`) blocks everything.

--- a/server/package.json
+++ b/server/package.json
@@ -96,6 +96,8 @@
     "validate:gate-index": "node scripts/generate-gate-index.js --check",
     "validate:frameworks": "tsx scripts/validate-frameworks.ts",
     "validate:readme": "node scripts/validate-readme.js --mode=block",
+    "validate:contributing": "node scripts/validate-contributing.js",
+    "validate:contributing:self-test": "node scripts/validate-contributing.js --self-test",
     "validate:conformance-coverage": "node scripts/validate-conformance-coverage.js",
     "validate:conformance-coverage:self-test": "node scripts/validate-conformance-coverage.js --self-test",
     "validate:versions": "node scripts/validate-versions.js",

--- a/server/scripts/run-validation-suite.js
+++ b/server/scripts/run-validation-suite.js
@@ -187,6 +187,17 @@ export const SUITE = [
     converse: 'unexamined',
   },
   {
+    // `spawn` is a TEXTUAL match, not a behavioural one: the SPAWN substrate pattern includes
+    // /\bnpm run\b/, and validate-contributing.js carries that literal inside the regex that
+    // extracts command references from CONTRIBUTING.md. The script shells out to nothing and
+    // imports only node: builtins, which the docs CI route requires. Declared rather than worked
+    // around, because the detector is textual by design and omitting a matched substrate fails.
+    script: 'validate:contributing',
+    io: 'read',
+    reads: ['file', 'spawn'],
+    converse: 'unexamined',
+  },
+  {
     script: 'validate:conformance-coverage',
     io: 'read',
     reads: ['file', 'walk'],

--- a/server/scripts/validate-contributing.js
+++ b/server/scripts/validate-contributing.js
@@ -1,0 +1,195 @@
+#!/usr/bin/env node
+
+/**
+ * Asserts every npm script CONTRIBUTING.md names actually exists.
+ *
+ * WHY THIS EXISTS
+ * CONTRIBUTING is prose describing an executable system, and it was the only contributor-facing
+ * contract here with no gate behind it. Comparable contracts each have one: validate:suite-membership
+ * for script membership, validate:standards-pins for version agreement, validate:readme for README
+ * structure, validate:documented-options for option coverage. Nothing read CONTRIBUTING, so four dead
+ * commands accumulated at four different times and none was caught: `start:sse` (removed with HTTP+SSE
+ * in the SDK v2 upgrade), `format`, `format:fix`, and `test:jest`.
+ *
+ * `start:sse` was not a cosmetic rot. It sat on the Decision Matrix row a contributor reads when
+ * changing transport behavior, and PR #204 changed transport behavior. The contributor smoke-tested
+ * STDIO only, because the other transport the row named did not exist. The bug was on both.
+ *
+ * ZERO DEPENDENCIES, ON PURPOSE
+ * `CONTRIBUTING.md` classifies as `docs` scope (scripts/classify-validation-scope.js), and ci.yml
+ * guards "Setup Node.js" on `scope != 'docs'` and "Install dependencies" on `scope == 'full'`. There
+ * is no node_modules on the docs route. A validator that imported anything would be unrunnable on
+ * exactly the pull requests that edit CONTRIBUTING, which is the only time it matters. Node builtins
+ * only. Keep it that way.
+ *
+ * DECLARED BLIND SPOT
+ * This checks that named commands EXIST. It does not check that a documented gate SEQUENCE matches
+ * scripts/run-validation-suite.js. That needs a parse of prose intent and would produce false
+ * positives on legitimate phrasing. A sequence drifting while every command still exists is not
+ * caught here. Recorded rather than silently absent, per the convention in validate-table-contracts.js.
+ *
+ * Exit 0 when every named command exists; exit 1 naming each one that does not.
+ */
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const SERVER_ROOT = path.resolve(new URL('..', import.meta.url).pathname);
+const REPO_ROOT = path.resolve(SERVER_ROOT, '..');
+const CONTRIBUTING = path.join(REPO_ROOT, 'CONTRIBUTING.md');
+const PACKAGE_JSON = path.join(SERVER_ROOT, 'package.json');
+
+/**
+ * Node builtin module specifiers look exactly like `namespace:script`.
+ *
+ * `node:sqlite` is cited in CONTRIBUTING for the Node floor and is not a command. Matching on shape
+ * alone reports it as a dead script, so the prefix is excluded by name rather than by guessing.
+ */
+const NON_SCRIPT_PREFIXES = ['node:', 'http:', 'https:', 'file:', 'npm:'];
+
+/**
+ * A bare backticked token that is a plausible script name.
+ *
+ * NO PREFIX ALLOWLIST. The first audit pass used one (`start|test|validate|typecheck|lint|build`)
+ * and missed `format:fix` outright, because the allowlist encoded the namespaces that happened to be
+ * known at the time. Any lowercase colon-joined token qualifies; false positives are removed by the
+ * builtin-prefix rule above, not by predicting namespaces.
+ */
+const SCRIPT_SHAPE = /^[a-z][a-z0-9-]*(?::[a-z0-9-]+)+$/;
+
+/** Every `npm run <script>` occurrence, with its 1-indexed line. */
+function extractNpmRunRefs(lines) {
+  const found = [];
+  lines.forEach((text, index) => {
+    for (const match of text.matchAll(/npm run ([a-z][a-z0-9:._-]*)/g)) {
+      found.push({ command: match[1], line: index + 1, form: 'npm run' });
+    }
+  });
+  return found;
+}
+
+/**
+ * Bare backticked script names, e.g. the `start:development` in
+ * "`npm run start:stdio` / `start:development`".
+ *
+ * This form is why the check exists in this shape: `start:sse` was written bare, so an `npm run`
+ * regex alone does not see the motivating instance.
+ */
+function extractBareRefs(lines) {
+  const found = [];
+  lines.forEach((text, index) => {
+    for (const match of text.matchAll(/`([^`]+)`/g)) {
+      const token = match[1].trim();
+      if (NON_SCRIPT_PREFIXES.some((prefix) => token.startsWith(prefix))) continue;
+      if (!SCRIPT_SHAPE.test(token)) continue;
+      found.push({ command: token, line: index + 1, form: 'bare' });
+    }
+  });
+  return found;
+}
+
+function collectReferences(markdown) {
+  const lines = markdown.split('\n');
+  return [...extractNpmRunRefs(lines), ...extractBareRefs(lines)];
+}
+
+/** Referenced commands with no matching entry in package.json scripts. */
+function findDeadCommands(markdown, scripts) {
+  const known = new Set(Object.keys(scripts));
+  const seen = new Set();
+  const dead = [];
+  for (const ref of collectReferences(markdown)) {
+    if (known.has(ref.command)) continue;
+    const key = `${ref.command}:${ref.line}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    dead.push(ref);
+  }
+  return dead;
+}
+
+/**
+ * Counterexamples, asserted rather than assumed.
+ *
+ * The first is the exact 4.0.0-era text. A gate that cannot fail on the drift that motivated it is
+ * not evidence of anything.
+ */
+function runSelfTest() {
+  const scripts = { 'start:stdio': '', 'start:development': '', test: '', 'validate:format': '' };
+  const cases = [
+    {
+      label: 'rejects the motivating instance (bare start:sse)',
+      markdown: '| `npm run start:stdio` / `start:sse` | Launch transports |',
+      expectDead: ['start:sse'],
+    },
+    {
+      label: 'rejects an `npm run` form',
+      markdown: 'Run `npm run format` before committing.',
+      expectDead: ['format'],
+    },
+    {
+      label: 'rejects a namespace no allowlist would have predicted',
+      markdown: 'Run `format:fix` to autoformat.',
+      expectDead: ['format:fix'],
+    },
+    {
+      label: 'accepts commands that exist, in both forms',
+      markdown: '`npm run start:stdio` / `start:development` and `npm run validate:format`',
+      expectDead: [],
+    },
+    {
+      label: 'does not report a node builtin as a dead script',
+      markdown: 'The floor is where `node:sqlite` needs no flag.',
+      expectDead: [],
+    },
+  ];
+
+  let failures = 0;
+  console.log('\nvalidate:contributing self-test\n');
+  for (const testCase of cases) {
+    const dead = findDeadCommands(testCase.markdown, scripts).map((entry) => entry.command);
+    const ok =
+      dead.length === testCase.expectDead.length &&
+      testCase.expectDead.every((command) => dead.includes(command));
+    console.log(
+      `  ${ok ? 'PASS' : 'FAIL'}  ${testCase.label}${ok ? '' : ` — got [${dead.join(', ')}]`}`
+    );
+    if (!ok) failures += 1;
+  }
+  console.log(
+    failures === 0
+      ? `\nOK: all ${cases.length} self-test cases behave as specified\n`
+      : `\nFAILED: ${failures} self-test case(s)\n`
+  );
+  process.exit(failures === 0 ? 0 : 1);
+}
+
+function main() {
+  if (process.argv.includes('--self-test')) {
+    runSelfTest();
+    return;
+  }
+
+  const markdown = readFileSync(CONTRIBUTING, 'utf8');
+  const { scripts } = JSON.parse(readFileSync(PACKAGE_JSON, 'utf8'));
+  const dead = findDeadCommands(markdown, scripts);
+  const total = collectReferences(markdown).length;
+
+  if (dead.length === 0) {
+    console.log(
+      `[validate-contributing] OK: ${total} command reference(s) in CONTRIBUTING.md all exist`
+    );
+    process.exit(0);
+  }
+
+  console.error(
+    `[validate-contributing] FAIL: ${dead.length} command(s) named by CONTRIBUTING.md do not exist\n`
+  );
+  for (const entry of dead) {
+    console.error(`  CONTRIBUTING.md:${entry.line}  ${entry.command}  (${entry.form} form)`);
+  }
+  console.error('\nEither add the script to server/package.json or correct CONTRIBUTING.md.');
+  process.exit(1);
+}
+
+main();

--- a/server/scripts/validate-documented-options.js
+++ b/server/scripts/validate-documented-options.js
@@ -62,6 +62,7 @@ const NOT_OUR_OPTIONS = new Set([
   '--strict', // npm run validate:identity-backfill -- --strict
   '--mode', // npm run validate:readme --mode=block
   '--test', // truncation of jest's --testPathPattern
+  '--experimental-vm-modules', // node runtime flag; jest needs it for ESM test files
   '--prefix', // npm --prefix server run build
   // Generic placeholder in "All flags accept both `--flag=value` and `--flag value`".
   '--flag',


### PR DESCRIPTION
Closes out the residuals sweep's paperwork after PR #231 merged:

- Residuals plan flipped to `status: reference` — table rewritten as a disposition record (10/15 fixed by the sweep, 5 re-homed)
- Open rows re-homed to verified live owners: P3-F5 + P4-F1 → project memories, P7-F4 + P7-F11 → settability matrix §Standing hazards, P7-F15 → packaged-defect memory
- Two of the old routes pointed at retired/completed queues — corrected
- `plans:retire:check` green; the release workflow's `--apply` performs the physical move to `plans/reference/`

https://claude.ai/code/session_01RusASnjXNGSWbEg4NgnJY3