### PR TITLE
fix: close both conformance-gate blockers from the test roadmap

### DIFF
--- a/docs/reference/workflow-ir.md
+++ b/docs/reference/workflow-ir.md
@@ -137,8 +137,12 @@ Split by enforcement posture, and the split is the contract.
 | `maxInsertions`       | **Enforced** | 3       | Narrows the adaptive-mutation insertion ceiling for the run.      |
 | `declaredCostCeiling` | Recorded     | —       | Recorded on the run. Never enforced, never compared.              |
 
-A declared cap may only **narrow** the server default. Asking for a wider one is rejected as
-`cap-exceeded` rather than silently clamped — a clamped run is a run you did not author.
+A declared cap may only **narrow** the server default. Asking for a wider one is rejected, not
+silently clamped — a clamped run is a run you did not author. The rejection happens at the `workflow`
+parameter's Zod schema (`.max(DEFAULT_WORKFLOW_CAPS.*)`), before the validator ever runs, so it
+surfaces as a schema validation error (e.g. `Too big: expected number to be <=32`) rather than a
+`cap-exceeded` rejection — no real submission can reach the validator with a wider cap to reject
+(MEASURED 2026-08-17).
 
 `declaredCostCeiling` is denominated in tokens the server never observes: the client meters those.
 Enforcing it would mean enforcing against a server-side estimate, which is a number precise enough
@@ -212,7 +216,7 @@ submission is fixed in one pass rather than one error per round trip.
 | `unknown-visibility-item`   | A `visibility` entry is outside the item vocabulary.                             |
 | `edge-endpoint-missing`     | An edge's `from` or `to` names no declared node.                                 |
 | `cycle`                     | Edges form a cycle. The detail names every node in the stuck set.                |
-| `cap-exceeded`              | A structural cap is breached, or a declared budget tries to widen one.           |
+| `cap-exceeded`              | The submission's node count or fan-out breaches the effective cap.               |
 | `gate-target-missing`       | A gate's `target_step_id` names no declared node, or an inline gate id is empty. |
 | `mutually-exclusive-source` | The call carried a workflow **and** a `command` or `chain_id`.                   |
 

--- a/plans/techincal_debt/test-modernization-roadmap.md
+++ b/plans/techincal_debt/test-modernization-roadmap.md
@@ -519,9 +519,18 @@ Carried findings (from the workflow-ir conformance work, PR pending):
   every bundled framework id appears in the corpus, but has no vocabulary for TOOL PARAMETERS:
   the `workflow` parameter shipped with zero conformance rows and no gate noticed. Candidate
   follow-up gate: parameter/claim coverage over `tooling/contracts/*.json` advertised surface.
-  ☐ (as of 2026-08-17 · flips when a parameter-coverage assertion exists in validate:all)
+  ✓ FLIPPED 2026-08-17 — validate-conformance-coverage.js extended with per-tool parameter
+  coverage (args-key structural match), 55 declared exceptions each with closedBy, shared
+  exception-hygiene audit (stale exceptions become findings), 11 self-test cases, +2 live
+  corpus cases in tool-surface.yaml. Measured: skills_sync has ZERO conformance corpus (all
+  12 params excepted — closedBy names the corpus file to create). In-tree, e2e re-verification
+  running, commit pending.
 - **Workflow-IR validator dead branch** — the validator's own cap-widening check for
   `maxNodes`/`maxFanOut`/`maxInsertions` is structurally unreachable from any real MCP client:
   the Zod schema (`workflowBudgetSchema` `.max(32)`) rejects widening first with a generic
   message. Delete-on-next-touch class (same shape as P7-F9).
-  ☐ (as of 2026-08-17 · flips when the validator branch is removed or a non-Zod ingress exists)
+  ✓ FLIPPED 2026-08-17 — branch deleted (validator.ts collectCapRejections widening loop + 2
+  widening-only unit tests); unreachability confirmed by full ingress enumeration (sole path
+  flows through the .strict() Zod boundary with identical cap values); `cap-exceeded` reason
+  retained (live producers remain); docs + contract corrected in lockstep. In-tree, commit
+  pending with the parameter-coverage gate.

--- a/server/scripts/validate-conformance-coverage.js
+++ b/server/scripts/validate-conformance-coverage.js
@@ -1,28 +1,44 @@
 #!/usr/bin/env node
-// validate-conformance-coverage.js — every bundled framework must have a claims-conformance scenario
+// validate-conformance-coverage.js — every bundled framework AND every advertised tool parameter
+// must have a claims-conformance scenario (or a declared, closeable exception).
 // Usage: node server/scripts/validate-conformance-coverage.js [--self-test]
-// Exit: 0 = every declared framework is exercised, 1 = one or more are not, 2 = invalid args
+// Exit: 0 = fully covered, 1 = one or more findings, 2 = invalid args
 //
-// WHY THIS EXISTS
+// WHY THIS EXISTS (framework half)
 // Plan row 0.5.14 found all 8 bundled frameworks already had scenarios — and that coverage was
 // held entirely by hand. Nothing failed when a framework shipped without one, so a 9th directory
 // under `resources/frameworks/` would have gone out unexercised and silently. The corpus can only
 // ever see the BUNDLED set: a user's own frameworks live in the operator-local tree that CI never
 // checks out, so "declared" here means the git-tracked directories and nothing else.
 //
+// WHY THIS EXISTS (parameter half, added 2026-08-17)
+// The framework check has no vocabulary for TOOL PARAMETERS: `workflow` shipped on `prompt_engine`
+// with zero conformance rows and this gate stayed green, because it only ever asked about
+// `resources/frameworks/`. Re-measured in `plans/techincal_debt/test-modernization-roadmap.md`
+// (Re-measurement 2026-08-17) as the first open finding — this is that finding's closer. The same
+// shape of gap: a declared surface (`tooling/contracts/*.json`) with no corpus cross-check.
+//
 // This is the same shape as validate-readme.js's claim-coverage check — a declared surface
-// cross-checked against the corpus that is supposed to exercise it — and it is deliberately narrow:
-// it asserts a scenario EXISTS naming the framework, not that the scenario is any good. Falsifying
-// what each scenario observes is the corpus's own job (`known_divergence`, error_contains).
+// cross-checked against the corpus that is supposed to exercise it — and both halves are
+// deliberately narrow: they assert a scenario EXISTS naming the framework/parameter, not that the
+// scenario is any good. Falsifying what each scenario observes is the corpus's own job
+// (`known_divergence`, `error_contains`).
 
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import * as yaml from 'js-yaml';
+
+import { auditExceptions, reportExceptionAudit, VERDICT } from './lib/exception-hygiene.js';
+
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const SERVER_ROOT = path.resolve(__dirname, '..');
 const FRAMEWORKS_DIR = path.join(SERVER_ROOT, 'resources', 'frameworks');
 const CORPUS_DIR = path.join(SERVER_ROOT, 'tests', 'e2e', 'conformance');
+const CONTRACTS_DIR = path.join(SERVER_ROOT, 'tooling', 'contracts');
+
+// ── Framework coverage (original check, unchanged) ───────────────────────────
 
 /** Framework ids the server ships, taken from the directory names it loads them from. */
 function declaredFrameworks(dir = FRAMEWORKS_DIR) {
@@ -63,12 +79,316 @@ function isExercised(framework, text) {
   return new RegExp(`\\b${framework.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`, 'i').test(text);
 }
 
-function findUncovered(frameworks, text) {
+function findUncoveredFrameworks(frameworks, text) {
   return frameworks.filter((f) => !isExercised(f, text));
 }
 
+// ── Parameter coverage (new) ──────────────────────────────────────────────────
+//
+// MATCHING RULE, chosen and documented here because parameter names collide with English words
+// (`command`, `gates`, `id`, `format`...) in a way framework ids do not:
+//
+//   A parameter counts as covered iff its name appears as a top-level KEY of an `args:` mapping
+//   on a request naming ITS tool, i.e. `requests: [{ tool: <tool>, args: { <parameter>: ... } }]`
+//   in `tests/e2e/claims-conformance.test.ts`'s own `ScenarioRequest` shape.
+//
+// Rejected alternative: free-text substring/word match (the framework rule above). `gates` and
+// `id` appear constantly in prose, comments, and OTHER tools' `args` blocks — a free-text match
+// would pass every one of them without a single scenario ever setting `gates:` on `prompt_engine`.
+// Scoping to "key of `args` on a request naming this tool" is the strictest rule that still passes
+// today's real coverage (verified against the corpus below) with no hand-written allowlist.
+// Comments need no separate stripping pass here (unlike the framework text match): a `#` line is
+// not a YAML mapping key, so js-yaml never surfaces it as one.
+
+/** Tool contracts, in the sense `generate-contracts.ts`'s `resolveContractPosture` calls `'tool'`.
+ *
+ * `resolveContractPosture` checks `contract.toolDescription` FIRST and unconditionally — a
+ * `resource-shape` or `artifact-less` contract (`metadata.artifactKind`) carries no
+ * `toolDescription` by construction, so `Boolean(contract.toolDescription)` reproduces exactly the
+ * resolver's `'tool'` branch without importing it: that module is TypeScript run under `tsx`, and
+ * this script runs under plain `node` like its framework half. `tooling/contracts/workflow-ir.json`
+ * (`artifactKind: 'resource-shape'`) is the contract this exists to skip — it describes an MCP
+ * value shape, not a registered tool's parameter list, and has no MCP surface for a conformance
+ * scenario to call.
+ */
+function loadToolContracts(dir = CONTRACTS_DIR) {
+  if (!fs.existsSync(dir)) return [];
+  return fs
+    .readdirSync(dir)
+    .filter((f) => f.endsWith('.json'))
+    .sort()
+    .map((f) => JSON.parse(fs.readFileSync(path.join(dir, f), 'utf8')))
+    .filter((contract) => Boolean(contract.toolDescription));
+}
+
+function parameterNames(contract) {
+  return (contract.parameters ?? []).map((p) => p.name);
+}
+
+/** `tool -> Set(parameter names seen as `args` keys for that tool)`, across the whole corpus. */
+function corpusArgsByTool(dir = CORPUS_DIR) {
+  const byTool = new Map();
+  if (!fs.existsSync(dir)) return byTool;
+  for (const file of fs.readdirSync(dir).filter((f) => f.endsWith('.yaml'))) {
+    collectCorpusArgs(fs.readFileSync(path.join(dir, file), 'utf8'), byTool);
+  }
+  return byTool;
+}
+
+/** Exported as its own function so the self-test can feed it fixture YAML text directly. */
+function collectCorpusArgs(yamlText, byTool = new Map()) {
+  const doc = yaml.load(yamlText);
+  for (const scenario of doc?.scenarios ?? []) {
+    for (const request of scenario?.requests ?? []) {
+      if (!request?.tool) continue;
+      const set = byTool.get(request.tool) ?? new Set();
+      for (const key of Object.keys(request.args ?? {})) set.add(key);
+      byTool.set(request.tool, set);
+    }
+  }
+  return byTool;
+}
+
+/**
+ * Declared parameter-coverage exceptions.
+ *
+ * Mirrors `AcceptedException` in `src/infra/database/table-contracts.ts`: every entry names a
+ * `reason` the parameter is uncovered today and a `closedBy` condition that would remove the
+ * entry. Audited by the shared `scripts/lib/exception-hygiene.js` (`auditExceptions`) below —
+ * the same module `validate-table-contracts.ts` uses — rather than a second hand-rolled
+ * stale/dangling check: an exception that stops describing the truth (SATISFIED — the parameter
+ * is now exercised) or never described anything (SUBJECT_MISSING — no contract advertises that
+ * parameter) must fail exactly like a bare empty `closedBy` does.
+ */
+function exceptionGroup(tool, parameters, reason, closedBy) {
+  return parameters.map((parameter) => ({ tool, parameter, reason, closedBy }));
+}
+
+const PARAMETER_COVERAGE_EXCEPTIONS = [
+  // ── prompt_engine ────────────────────────────────────────────────────────
+  ...exceptionGroup(
+    'prompt_engine',
+    ['gates'],
+    'Quick-gate / gate-definition arrays put the run into the interactive gate-verdict retry ' +
+      'loop (chain_id + gate_verdict resume) that chain-lifecycle.yaml already drives for ' +
+      'gate_verdict/gate_action — but always via a fixture prompt that DECLARES a gate. No such ' +
+      'fixture is wired to a `gates:` argument today.',
+    'A conformance scenario that submits `gates:` on a chain-triggering prompt and drives the ' +
+      'resulting gate_verdict resume to completion, mirroring chain-lifecycle.yaml.'
+  ),
+  ...exceptionGroup(
+    'prompt_engine',
+    ['options'],
+    '`options` is an open `record` "forwarded downstream" with no single observable effect ' +
+      'documented in the contract to assert against.',
+    'A conformance scenario once `options` gains a documented, corpus-assertable effect.'
+  ),
+  ...exceptionGroup(
+    'prompt_engine',
+    ['observations'],
+    'Requires composing a typed `{type, id, statement, ...}` payload against a chain fixture and ' +
+      'reading back the per-run unknowns ledger — a multi-turn setup no existing scenario builds.',
+    'A conformance scenario that declares an observation and asserts it in the unknowns ledger ' +
+      'readback (system_control action:status or execution_history).'
+  ),
+
+  // ── system_control ──────────────────────────────────────────────────────
+  ...exceptionGroup(
+    'system_control',
+    ['session_id'],
+    'Session-scoped operations need an existing session/chain id to target; the shared read-only ' +
+      'server (tool-surface.yaml) runs no scenario that mints one first.',
+    'A conformance scenario pairing a chain-lifecycle run with a session_id-scoped system_control ' +
+      'call against that run.'
+  ),
+  ...exceptionGroup(
+    'system_control',
+    ['reason', 'persist'],
+    'Audit `reason` and `persist:true` are only meaningful alongside a framework/gate toggle that ' +
+      'writes config.json — a mutation unsafe to run against the shared read-only server that ' +
+      'tool-surface.yaml uses for every system_control row.',
+    'An isolated-workspace scenario (like workspace-and-mutations.yaml) toggling a framework or ' +
+      'gate with `persist:true` and a `reason` set.'
+  ),
+  ...exceptionGroup(
+    'system_control',
+    ['show_details', 'include_history'],
+    'Detail/history-inclusion toggles for status, analytics, framework, gate, and session reports; ' +
+      'no scenario asserts a detailed-vs-summary or with/without-history distinction today.',
+    'A conformance scenario asserting text present only in the detailed or history-inclusive ' +
+      'report, distinguishing it from the current default-level assertions.'
+  ),
+
+  // ── resource_manager ─────────────────────────────────────────────────────
+  ...exceptionGroup(
+    'resource_manager',
+    [
+      'system_message',
+      'arguments',
+      'argument_updates',
+      'patch',
+      'dry_run',
+      'chain_steps',
+      'tools',
+      'gate_configuration',
+      'injection',
+      'register_with_mcp',
+      'mcp_prompt_mode',
+      'subagent_model',
+      'agent_type',
+      'execution_hint',
+    ],
+    'Prompt create/update payload field. workspace-and-mutations.yaml exercises `create` with ' +
+      'only name/category/description/user_message_template, and `update` with only ' +
+      'user_message_template — this field has no scenario yet.',
+    'An isolated-workspace scenario creating or updating a prompt with this field set, asserting ' +
+      "an effect that distinguishes it from the field's default."
+  ),
+  ...exceptionGroup(
+    'resource_manager',
+    ['reason'],
+    'Audit `reason` for reload/delete/switch; workspace-and-mutations.yaml exercises delete and ' +
+      'reload without ever setting it.',
+    'A conformance scenario deleting or reloading a resource with `reason` set, confirmed in the ' +
+      "response or a subsequent read of the resource's audit trail."
+  ),
+  ...exceptionGroup(
+    'resource_manager',
+    ['enabled_only', 'filter', 'format', 'search_query'],
+    'resource_manager list-action refinement field; every `list` scenario in the corpus uses ' +
+      'default arguments (`{resource_type, action: list}`) only.',
+    'A conformance scenario asserting the filtered/formatted list output differs from the ' +
+      'unfiltered default.'
+  ),
+  ...exceptionGroup(
+    'resource_manager',
+    ['gate_type', 'guidance', 'pass_criteria', 'activation', 'retry_config'],
+    'gate resource_type create/update payload field; the corpus exercises resource_type:gate ' +
+      'only via read-only `inspect` on a bundled gate (`resource-manager-gate-inspect`), never ' +
+      'create/update.',
+    'An isolated-workspace scenario creating or updating a gate resource with this field set.'
+  ),
+  ...exceptionGroup(
+    'resource_manager',
+    [
+      'framework',
+      'system_prompt_guidance',
+      'phases',
+      'gates',
+      'tool_descriptions',
+      'enabled',
+      'persist',
+    ],
+    'framework resource_type create/update payload field; the corpus exercises ' +
+      'resource_type:framework only via read-only `inspect` (`resource-manager-framework-inspect`). ' +
+      'Framework `switch` itself is exercised through system_control, a different tool contract.',
+    'An isolated-workspace scenario creating or updating a framework resource with this field set.'
+  ),
+  ...exceptionGroup(
+    'resource_manager',
+    ['from_version', 'to_version', 'limit', 'skip_version'],
+    'Versioning field beyond rollback\'s `version`; the corpus exercises `action:rollback` (with ' +
+      '`version`) but not `action:compare` (from_version/to_version), `action:history` (limit), ' +
+      'or an update carrying skip_version.',
+    'A conformance scenario exercising `action:compare` or `action:history`, or an update with ' +
+      'skip_version:true asserting no new version was saved.'
+  ),
+
+  // ── skills_sync ──────────────────────────────────────────────────────────
+  ...exceptionGroup(
+    'skills_sync',
+    [
+      'action',
+      'client',
+      'scope',
+      'resource_type',
+      'id',
+      'prune',
+      'dry_run',
+      'output',
+      'file',
+      'category',
+      'preview',
+      'force',
+    ],
+    'skills_sync has no conformance corpus file at all — the tool ships zero scenarios, so every ' +
+      'one of its parameters is unexercised.',
+    'A tests/e2e/conformance/skills-sync.yaml file with at least one scenario per parameter, ' +
+      "mirroring the other three tools' corpus files."
+  ),
+];
+
+/**
+ * Every advertised (tool, parameter) pair not covered by the corpus and not named by any
+ * declared exception. The exceptions themselves are audited separately, by `auditExceptions`
+ * below — this function only reports parameters that carry NO exception at all.
+ */
+function findUncoveredParameters(contracts, argsByTool, exceptions = PARAMETER_COVERAGE_EXCEPTIONS) {
+  const exceptionKeys = new Set(exceptions.map((e) => `${e.tool}::${e.parameter}`));
+  const problems = [];
+
+  for (const contract of contracts) {
+    const covered = argsByTool.get(contract.tool) ?? new Set();
+    for (const parameter of parameterNames(contract)) {
+      if (covered.has(parameter)) continue;
+      if (exceptionKeys.has(`${contract.tool}::${parameter}`)) continue;
+      problems.push(
+        `${contract.tool}.${parameter} has no conformance scenario and no declared exception — ` +
+          'add a scenario or declare one in PARAMETER_COVERAGE_EXCEPTIONS.'
+      );
+    }
+  }
+
+  return problems;
+}
+
+/**
+ * Audits `PARAMETER_COVERAGE_EXCEPTIONS` via the shared exception-hygiene contract: an entry
+ * must suppress a real, currently-true finding — a parameter genuinely uncovered by the corpus,
+ * on a parameter that actually exists on a loaded tool contract. SATISFIED (parameter is now
+ * covered) and SUBJECT_MISSING (parameter doesn't exist) both fail, same as an empty `closedBy`.
+ */
+function auditParameterExceptions(
+  contracts,
+  argsByTool,
+  exceptions = PARAMETER_COVERAGE_EXCEPTIONS
+) {
+  const knownPairs = new Set();
+  for (const contract of contracts) {
+    for (const parameter of parameterNames(contract)) {
+      knownPairs.add(`${contract.tool}::${parameter}`);
+    }
+  }
+
+  return auditExceptions({
+    gate: 'conformance-coverage:parameters',
+    entries: exceptions,
+    describe: (exception) => `${exception.tool}.${exception.parameter}`,
+    closedBy: (exception) => exception.closedBy,
+    classify: (exception) => {
+      const key = `${exception.tool}::${exception.parameter}`;
+      if (!knownPairs.has(key)) {
+        return {
+          verdict: VERDICT.SUBJECT_MISSING,
+          detail: 'no loaded tool contract advertises this parameter',
+        };
+      }
+      const covered = argsByTool.get(exception.tool) ?? new Set();
+      if (covered.has(exception.parameter)) {
+        return { verdict: VERDICT.SATISFIED, detail: 'the parameter is now exercised in the corpus' };
+      }
+      return { verdict: VERDICT.LOAD_BEARING };
+    },
+  });
+}
+
+// ── Self-test ─────────────────────────────────────────────────────────────────
+
 function selfTest() {
-  const cases = [
+  const cases = [];
+
+  // (Framework half — unchanged.)
+  const frameworkCases = [
     { name: 'covered framework passes', fw: ['cageerf'], text: 'command: ^cageerf >>x', want: 0 },
     { name: 'missing framework fails', fw: ['newthing'], text: 'command: ^cageerf >>x', want: 1 },
     {
@@ -84,16 +404,145 @@ function selfTest() {
       want: 1,
     },
   ];
-  let failed = 0;
-  for (const c of cases) {
+  for (const c of frameworkCases) {
     const stripped = c.text
       .split('\n')
       .map((l) => l.replace(/#.*$/, ''))
       .join('\n');
-    const got = findUncovered(c.fw, stripped).length;
-    const ok = got === c.want;
-    if (!ok) failed++;
-    console.log(`${ok ? '✓' : '✗'} ${c.name} (expected ${c.want} uncovered, got ${got})`);
+    const got = findUncoveredFrameworks(c.fw, stripped).length;
+    cases.push({ name: c.name, ok: got === c.want, detail: `expected ${c.want}, got ${got}` });
+  }
+
+  // (Parameter half — new.)
+  const fixtureContract = (parameters) => ({
+    tool: 'fake_tool',
+    toolDescription: { description: 'fixture' },
+    parameters: parameters.map((name) => ({ name })),
+  });
+
+  // (a) a parameter present in the corpus passes.
+  {
+    const argsByTool = collectCorpusArgs(
+      "scenarios:\n  - id: x\n    requests: [{ tool: fake_tool, args: { my_param: 'v' } }]\n"
+    );
+    const uncovered = findUncoveredParameters([fixtureContract(['my_param'])], argsByTool, []);
+    const audit = auditParameterExceptions([fixtureContract(['my_param'])], argsByTool, []);
+    cases.push({
+      name: 'covered parameter passes',
+      ok: uncovered.length === 0 && audit.problems.length === 0,
+      detail: JSON.stringify({ uncovered, auditProblems: audit.problems }),
+    });
+  }
+
+  // (b) a missing parameter fails, naming tool + parameter.
+  {
+    const argsByTool = collectCorpusArgs(
+      "scenarios:\n  - id: x\n    requests: [{ tool: fake_tool, args: { other: 'v' } }]\n"
+    );
+    const uncovered = findUncoveredParameters([fixtureContract(['missing_param'])], argsByTool, []);
+    cases.push({
+      name: 'missing parameter fails naming tool+parameter',
+      ok:
+        uncovered.length === 1 &&
+        uncovered[0].includes('fake_tool.missing_param') &&
+        uncovered[0].includes('no conformance scenario'),
+      detail: JSON.stringify(uncovered),
+    });
+  }
+
+  // (c) a declared exception with a valid closedBy suppresses the finding.
+  {
+    const argsByTool = collectCorpusArgs('scenarios: []\n');
+    const exceptions = [
+      { tool: 'fake_tool', parameter: 'excused_param', reason: 'fixture', closedBy: 'fixture tier' },
+    ];
+    const contracts = [fixtureContract(['excused_param'])];
+    const uncovered = findUncoveredParameters(contracts, argsByTool, exceptions);
+    const audit = auditParameterExceptions(contracts, argsByTool, exceptions);
+    cases.push({
+      name: 'valid exception suppresses the finding',
+      ok: uncovered.length === 0 && audit.problems.length === 0,
+      detail: JSON.stringify({ uncovered, auditProblems: audit.problems }),
+    });
+  }
+
+  // (d) an exception with an empty closedBy is itself a failure.
+  {
+    const argsByTool = collectCorpusArgs('scenarios: []\n');
+    const exceptions = [
+      { tool: 'fake_tool', parameter: 'excused_param', reason: 'fixture', closedBy: '   ' },
+    ];
+    const audit = auditParameterExceptions(
+      [fixtureContract(['excused_param'])],
+      argsByTool,
+      exceptions
+    );
+    cases.push({
+      name: 'exception with empty closedBy is rejected',
+      ok:
+        audit.problems.length === 1 && audit.problems[0].message.includes('no closedBy'),
+      detail: JSON.stringify(audit.problems),
+    });
+  }
+
+  // (e) framework coverage behavior is unchanged — covered above via frameworkCases; this case
+  // additionally proves the two checks are independent (a parameter fixture cannot mask a
+  // framework finding or vice versa, since main() combines both problem lists).
+  {
+    const uncoveredFrameworksHere = findUncoveredFrameworks(['cageerf'], 'command: ^cageerf >>x');
+    const argsByTool = collectCorpusArgs(
+      "scenarios:\n  - id: x\n    requests: [{ tool: fake_tool, args: { my_param: 'v' } }]\n"
+    );
+    const uncoveredParams = findUncoveredParameters([fixtureContract(['my_param'])], argsByTool, []);
+    cases.push({
+      name: 'framework and parameter checks are independent',
+      ok: uncoveredFrameworksHere.length === 0 && uncoveredParams.length === 0,
+      detail: `frameworks=${JSON.stringify(uncoveredFrameworksHere)} params=${JSON.stringify(uncoveredParams)}`,
+    });
+  }
+
+  // Bonus: stale (SATISFIED) and dangling (SUBJECT_MISSING) exceptions are caught by the shared
+  // `auditExceptions` module — the exact blind spot `.claude/rules/sqlite-persistence.md` names
+  // for `AcceptedException`: an entry that stops describing reality passes silently otherwise.
+  {
+    const argsByTool = collectCorpusArgs(
+      "scenarios:\n  - id: x\n    requests: [{ tool: fake_tool, args: { now_covered: 'v' } }]\n"
+    );
+    const exceptions = [
+      { tool: 'fake_tool', parameter: 'now_covered', reason: 'fixture', closedBy: 'fixture tier' },
+    ];
+    const audit = auditParameterExceptions(
+      [fixtureContract(['now_covered'])],
+      argsByTool,
+      exceptions
+    );
+    cases.push({
+      name: 'stale (SATISFIED) exception is flagged',
+      ok: audit.problems.length === 1 && audit.problems[0].message.includes(VERDICT.SATISFIED),
+      detail: JSON.stringify(audit.problems),
+    });
+  }
+  {
+    const argsByTool = collectCorpusArgs('scenarios: []\n');
+    const exceptions = [
+      { tool: 'fake_tool', parameter: 'real_param', reason: 'fixture', closedBy: 'fixture' },
+      { tool: 'fake_tool', parameter: 'nonexistent_param', reason: 'fixture', closedBy: 'fixture' },
+    ];
+    const audit = auditParameterExceptions([fixtureContract(['real_param'])], argsByTool, exceptions);
+    cases.push({
+      name: 'dangling (SUBJECT_MISSING) exception is flagged',
+      ok:
+        audit.problems.length === 1 &&
+        audit.problems[0].message.includes(VERDICT.SUBJECT_MISSING) &&
+        audit.problems[0].subject.includes('nonexistent_param'),
+      detail: JSON.stringify(audit.problems),
+    });
+  }
+
+  let failed = 0;
+  for (const c of cases) {
+    if (!c.ok) failed++;
+    console.log(`${c.ok ? '✓' : '✗'} ${c.name}${c.ok ? '' : ` (${c.detail})`}`);
   }
   if (failed > 0) {
     console.error(`\n✗ self-test: ${failed} case(s) failed`);
@@ -102,6 +551,8 @@ function selfTest() {
   console.log('\n✓ self-test: all cases passed');
   process.exit(0);
 }
+
+// ── Entry point ────────────────────────────────────────────────────────────────
 
 const argv = process.argv.slice(2);
 for (const a of argv) {
@@ -118,21 +569,52 @@ if (frameworks.length === 0) {
   process.exit(1);
 }
 
-const uncovered = findUncovered(frameworks, corpusCommandText());
-
-if (uncovered.length > 0) {
-  console.error('✗ bundled frameworks with no claims-conformance scenario:\n');
-  for (const f of uncovered) {
-    console.error(`  ${f}  — add a scenario to ${path.relative(SERVER_ROOT, CORPUS_DIR)}/`);
-  }
-  console.error(
-    `\n${uncovered.length} of ${frameworks.length} bundled frameworks ship unexercised.\n` +
-      'A framework users receive but no scenario runs is a claim nothing verifies.'
-  );
+const toolContracts = loadToolContracts();
+if (toolContracts.length === 0) {
+  console.error(`✗ no tool contracts found under ${path.relative(SERVER_ROOT, CONTRACTS_DIR)}`);
   process.exit(1);
 }
 
+const argsByTool = corpusArgsByTool();
+const uncoveredFrameworks = findUncoveredFrameworks(frameworks, corpusCommandText());
+const uncoveredParameters = findUncoveredParameters(toolContracts, argsByTool);
+const exceptionAudit = auditParameterExceptions(toolContracts, argsByTool);
+
+let failed = false;
+
+if (uncoveredFrameworks.length > 0) {
+  failed = true;
+  console.error('✗ bundled frameworks with no claims-conformance scenario:\n');
+  for (const f of uncoveredFrameworks) {
+    console.error(`  ${f}  — add a scenario to ${path.relative(SERVER_ROOT, CORPUS_DIR)}/`);
+  }
+  console.error(
+    `\n${uncoveredFrameworks.length} of ${frameworks.length} bundled frameworks ship unexercised.\n` +
+      'A framework users receive but no scenario runs is a claim nothing verifies.'
+  );
+}
+
+if (uncoveredParameters.length > 0) {
+  failed = true;
+  if (uncoveredFrameworks.length > 0) console.error('');
+  console.error('✗ tool parameters with no conformance scenario and no declared exception:\n');
+  for (const problem of uncoveredParameters) {
+    console.error(`  ${problem}`);
+  }
+  console.error(
+    `\n${uncoveredParameters.length} finding(s) across ${toolContracts.length} tool contract(s).`
+  );
+}
+
+const exceptionProblemCount = reportExceptionAudit('conformance-coverage:parameters', exceptionAudit);
+if (exceptionProblemCount > 0) failed = true;
+
+if (failed) process.exit(1);
+
+const totalParameters = toolContracts.reduce((n, c) => n + parameterNames(c).length, 0);
 console.log(
   `✓ conformance coverage: all ${frameworks.length} bundled frameworks exercised ` +
-    `(${frameworks.join(', ')})`
+    `(${frameworks.join(', ')})\n` +
+    `✓ conformance coverage: all ${totalParameters} advertised parameters across ` +
+    `${toolContracts.length} tool contracts are covered or exempted`
 );

--- a/server/src/mcp/contracts/schemas/_generated/workflow_ir.generated.ts
+++ b/server/src/mcp/contracts/schemas/_generated/workflow_ir.generated.ts
@@ -70,7 +70,7 @@ export const workflow_irParameters: ToolParameter[] = [
     name: 'budget',
     type: 'object',
     description:
-      '[Workflow IR] Declared budget, split by enforcement posture. ENFORCED (structural, counted server-side): maxNodes, maxFanOut, maxInsertions — each may only NARROW the server cap, never widen it; a wider value is rejected as `cap-exceeded` rather than silently clamped. RECORDED ONLY: declaredCostCeiling, written to the existing execution_records telemetry object and never enforced, because the server never observes client token usage.',
+      '[Workflow IR] Declared budget, split by enforcement posture. ENFORCED (structural, counted server-side): maxNodes, maxFanOut, maxInsertions — each may only NARROW the server cap, never widen it; a wider value is rejected, not silently clamped. RECORDED ONLY: declaredCostCeiling, written to the existing execution_records telemetry object and never enforced, because the server never observes client token usage.',
     required: false,
     status: 'working',
     compatibility: 'canonical',

--- a/server/src/modules/workflow-ir/types.ts
+++ b/server/src/modules/workflow-ir/types.ts
@@ -88,8 +88,11 @@ export interface WorkflowEdge {
  * already rejected.
  *
  * A declared structural cap may only NARROW the server default. A submission asking for a wider
- * cap than the server allows is `cap-exceeded`, not a silent clamp: a clamped run is a run the
- * client did not author.
+ * cap than the server allows is rejected, not silently clamped — a clamped run is a run the
+ * client did not author. Enforced at the MCP tool boundary (`workflowBudgetSchema`'s
+ * `.max(DEFAULT_WORKFLOW_CAPS.*)`, `mcp/tools/schemas/workflow-ir.schema.ts`): the widening
+ * rejection formerly lived in {@link validateWorkflowIR} too, but every real ingress reaches the
+ * schema first, so that copy was unreachable and was deleted (MEASURED 2026-08-17).
  */
 export interface WorkflowBudget {
   /** ENFORCED — may only narrow {@link DEFAULT_WORKFLOW_CAPS}.maxNodes. */
@@ -180,7 +183,10 @@ export interface WorkflowPromptInfo {
   readonly requiredArguments: readonly string[];
 }
 
-/** Structural caps the server enforces. A submission's `budget` may narrow these, never widen. */
+/**
+ * Structural caps the server enforces. A submission's `budget` may narrow these, never widen —
+ * widening is rejected at the Zod schema boundary (`workflow-ir.schema.ts`), not here.
+ */
 export interface WorkflowCaps {
   readonly maxNodes: number;
   readonly maxFanOut: number;
@@ -192,9 +198,10 @@ export interface WorkflowCaps {
  *
  * `maxInsertions` mirrors `MAX_INSERTIONS_PER_RUN` rather than importing it: `modules/` may
  * value-import `engine/`, but tying the IR's declared submission ceiling to the runtime's
- * adaptive-mutation ceiling would make a change to one silently retune the other. The validator
- * asserts the relationship instead (a declared value may only narrow), and a drift test pins the
- * two numbers together so the mirror cannot rot silently.
+ * adaptive-mutation ceiling would make a change to one silently retune the other. The Zod schema
+ * asserts the relationship instead (a declared value may only narrow — `workflowBudgetSchema`'s
+ * `.max()` bound), and a drift test pins the two numbers together so the mirror cannot rot
+ * silently.
  */
 export const DEFAULT_WORKFLOW_CAPS: WorkflowCaps = {
   maxNodes: 32,

--- a/server/src/modules/workflow-ir/validator.ts
+++ b/server/src/modules/workflow-ir/validator.ts
@@ -125,10 +125,13 @@ function collectIdRejections(
 /**
  * Structural caps.
  *
- * Two distinct failures share the `cap-exceeded` reason and the detail distinguishes them:
- * the submission exceeds an effective cap, or the submission's own declared budget tries to
- * WIDEN a server cap. Both are "you asked for more than is allowed", and splitting them into two
- * reasons would make a client branch on a distinction it cannot act on differently.
+ * A declared budget may only narrow a server cap, never widen it — but that constraint is
+ * enforced at the MCP tool boundary (`workflowBudgetSchema`'s `.max(DEFAULT_WORKFLOW_CAPS.*)`),
+ * not here: every real ingress into this validator has already passed that schema, so a
+ * `declaredValue > serverValue` widening attempt can never reach this function (MEASURED
+ * 2026-08-17, `tests/e2e/conformance/workflow-ir.yaml`'s `workflow-rejects-cap-widening` case
+ * asserts the Zod-layer rejection instead). What remains here is the one reachable failure: the
+ * submission itself, measured against the effective (narrowed) cap, exceeds it.
  */
 function collectCapRejections(
   ir: WorkflowIR,
@@ -136,20 +139,6 @@ function collectCapRejections(
   rejections: WorkflowRejection[]
 ): void {
   const declared = ir.budget;
-
-  for (const [key, serverValue] of [
-    ['maxNodes', serverCaps.maxNodes],
-    ['maxFanOut', serverCaps.maxFanOut],
-    ['maxInsertions', serverCaps.maxInsertions],
-  ] as const) {
-    const declaredValue = declared?.[key];
-    if (declaredValue !== undefined && declaredValue > serverValue) {
-      rejections.push({
-        reason: 'cap-exceeded',
-        detail: `budget.${key} of ${declaredValue} exceeds the server cap of ${serverValue}; a declared budget may only narrow a cap, never widen it`,
-      });
-    }
-  }
 
   const effectiveMaxNodes = Math.min(serverCaps.maxNodes, declared?.maxNodes ?? Infinity);
   if (ir.nodes.length > effectiveMaxNodes) {

--- a/server/tests/e2e/conformance/tool-surface.yaml
+++ b/server/tests/e2e/conformance/tool-surface.yaml
@@ -29,6 +29,18 @@ scenarios:
     requests: [{ tool: system_control, args: { action: gates, operation: list } }]
     expect: { ok: true }
 
+  - id: sc-gates-list-search-query
+    claim_source: >-
+      system_control contract — `search_query` "Filter gates by keyword (matches ID, name, or
+      description)". gate-action-handler.ts:244 prints `Filtered by: "<query>"` only when a
+      search_query was supplied.
+    requests:
+      - tool: system_control
+        args: { action: gates, operation: list, search_query: content }
+    # The bundled `content-structure` gate id contains "content", so a working filter keeps it
+    # AND prints the filter banner — a query that silently no-oped would still answer `ok: true`.
+    expect: { text_contains: 'Filtered by: "content"' }
+
   - id: sc-analytics
     claim_source: 'system_control action: analytics — docs/guides/telemetry-observability.md'
     requests: [{ tool: system_control, args: { action: analytics, operation: view } }]
@@ -43,6 +55,16 @@ scenarios:
     claim_source: 'system_control action: guide'
     requests: [{ tool: system_control, args: { action: guide } }]
     expect: { ok: true }
+
+  - id: sc-guide-topic
+    claim_source: >-
+      system_control contract — `topic` "Guide topic when requesting guidance".
+      guide-action-handler.ts:28-31 prints `Focus: \`<topic>\`` only when a topic was supplied,
+      versus the untopiced hint line asserted by sc-guide above.
+    requests:
+      - tool: system_control
+        args: { action: guide, topic: framework }
+    expect: { text_contains: 'Focus: `framework`' }
 
   - id: sc-injection
     claim_source: 'system_control action: injection — docs/guides/injection-control.md'

--- a/server/tests/unit/workflow-ir/validator.test.ts
+++ b/server/tests/unit/workflow-ir/validator.test.ts
@@ -223,25 +223,12 @@ describe('validateWorkflowIR — structural caps (ENFORCED)', () => {
     expect(reasons(result)).toEqual(['cap-exceeded']);
   });
 
-  it('rejects a declared budget that tries to WIDEN a cap, rather than clamping it', () => {
-    // A clamped run is a run the client did not author. Both the widening attempt and (if the
-    // submission is also oversized) the size breach are reported.
-    const result = validateWorkflowIR(
-      ir({ budget: { maxNodes: DEFAULT_WORKFLOW_CAPS.maxNodes + 10 } }),
-      deps()
-    );
-    expect(result.ok).toBe(false);
-    if (result.ok) throw new Error('unreachable');
-    expect(result.rejections[0]?.detail).toContain('may only narrow');
-  });
-
-  it('rejects a maxInsertions above the P4 adaptive-insertion ceiling', () => {
-    const result = validateWorkflowIR(
-      ir({ budget: { maxInsertions: DEFAULT_WORKFLOW_CAPS.maxInsertions + 1 } }),
-      deps()
-    );
-    expect(reasons(result)).toEqual(['cap-exceeded']);
-  });
+  // A declared budget that tries to WIDEN a cap (maxNodes/maxFanOut/maxInsertions above the
+  // server default) was formerly rejected here too, but that rejection was unreachable from any
+  // real MCP client: `workflowBudgetSchema`'s `.max(DEFAULT_WORKFLOW_CAPS.*)` already rejects the
+  // same submission at the tool-input layer, before this validator ever runs. Deleted with the
+  // branch (MEASURED 2026-08-17) — see `tests/e2e/conformance/workflow-ir.yaml`'s
+  // `workflow-rejects-cap-widening` case for the reachable (Zod-layer) version of this claim.
 });
 
 describe('validateWorkflowIR — declared cost ceilings are RECORDED, never enforced', () => {

--- a/server/tooling/contracts/workflow-ir.json
+++ b/server/tooling/contracts/workflow-ir.json
@@ -45,7 +45,7 @@
     {
       "name": "budget",
       "type": "object",
-      "description": "[Workflow IR] Declared budget, split by enforcement posture. ENFORCED (structural, counted server-side): maxNodes, maxFanOut, maxInsertions — each may only NARROW the server cap, never widen it; a wider value is rejected as `cap-exceeded` rather than silently clamped. RECORDED ONLY: declaredCostCeiling, written to the existing execution_records telemetry object and never enforced, because the server never observes client token usage.",
+      "description": "[Workflow IR] Declared budget, split by enforcement posture. ENFORCED (structural, counted server-side): maxNodes, maxFanOut, maxInsertions — each may only NARROW the server cap, never widen it; a wider value is rejected, not silently clamped. RECORDED ONLY: declaredCostCeiling, written to the existing execution_records telemetry object and never enforced, because the server never observes client token usage.",
       "required": false,
       "status": "working",
       "compatibility": "canonical",


### PR DESCRIPTION
Closes the two stamped findings in `plans/techincal_debt/test-modernization-roadmap.md` §Re-measurement 2026-08-17:

1. **Parameter-coverage gate** — `validate:conformance-coverage` now asserts every advertised tool parameter appears as an `args` key on a request naming its tool in the conformance corpus, or carries a declared exception with a falsifiable `closedBy` (audited by the shared exception-hygiene module — stale exceptions become findings). 55 exceptions declared; 2 new live corpus cases; 11 self-test cases; red/green falsified against real contracts. Measured en route: `skills_sync` has zero conformance corpus (all 12 params excepted with the corpus file named as `closedBy`).
2. **Dead cap-widening branch deleted** — the workflow-IR validator's widening rejection was unreachable from every real ingress (the `.strict()` Zod boundary rejects first with identical cap values; full caller enumeration in the commit). Branch + 2 widening-only tests deleted; docs and contract description corrected in lockstep; `cap-exceeded` retained (live producers remain).

Validation: e2e conformance 145 passed (both new cases live), targeted workflow-ir suites 93 passed, typecheck + tests-ratchet clean, gate self-test 11/11, full pre-push validation green.

https://claude.ai/code/session_01RusASnjXNGSWbEg4NgnJY3