### PR TITLE
docs: restore subagent-delegation-contract plan to active

### DIFF
--- a/plans/subagent-delegation-contract-2026-08-12-implementation-notes.md
+++ b/plans/subagent-delegation-contract-2026-08-12-implementation-notes.md
@@ -2,7 +2,7 @@
 title: "Sub-agent Delegation Contract — Implementation Notes"
 plan: subagent-delegation-contract-2026-08-12.md
 date: 2026-08-12
-status: reference
+status: active
 tags: []
 ---
 

--- a/plans/subagent-delegation-contract-2026-08-12.md
+++ b/plans/subagent-delegation-contract-2026-08-12.md
@@ -1,18 +1,11 @@
 ---
 title: "Sub-agent Delegation Contract — Envelope, Gates, and Agent Export"
 date: 2026-08-12
-status: reference
+status: active
 tags: []
 ---
 
 # Sub-agent Delegation Contract — Envelope, Gates, and Agent Export
-
-**Retired to reference 2026-08-17 (owner decision) with tiers S1–S6 UNEXECUTED.** The live
-signal — measured delegation defect (envelope carries no chain history, no gate text) and the
-S1–S6 scope with falsifiers — is re-homed to the `project_subagent_delegation_defect` memory.
-This document is the full-fidelity record; it is no longer a queue. Any future delegation work
-starts at S6 (re-measure against a fresh build) — the codebase moved substantially after this
-plan was written.
 
 **Work type**: bug_fix (S1–S4) + feature (S5, migrated from the adaptive-chain master plan as P8)
 **Origin**: owner report 2026-08-12 — "sub-agents aren't receiving the context, or gates, from the


### PR DESCRIPTION
Reverts the plan-side of PR #237 — the delegation-contract plan was retired in error (the owner's retirement scope was the residuals plan + test roadmap). S1–S6 are unexecuted live work for a measured defect, and the residuals ledger routes P5-F1 here. Both files restored byte-exact to their pre-retirement state; the roadmap's retirement stands.

https://claude.ai/code/session_01RusASnjXNGSWbEg4NgnJY3