### PR TITLE
docs(docs): retire the semantic module governance plan to reference

### DIFF
--- a/plans/reference/features/semantic-module-governance-2026-08-21-implementation-notes.md
+++ b/plans/reference/features/semantic-module-governance-2026-08-21-implementation-notes.md
@@ -2,7 +2,7 @@
 title: "Canonical agent instructions and semantic module governance — implementation notes"
 plan: semantic-module-governance-2026-08-21.md
 date: 2026-08-23
-status: active
+status: reference
 tags: [architecture, implementation-notes, dependency-cruiser]
 ---
 

--- a/plans/reference/features/semantic-module-governance-2026-08-21.md
+++ b/plans/reference/features/semantic-module-governance-2026-08-21.md
@@ -1,7 +1,7 @@
 ---
 title: "Canonical agent instructions and semantic module governance"
 date: 2026-08-21
-status: active
+status: reference
 tags: [architecture, documentation, validation, dependency-cruiser]
 ---
 
@@ -572,10 +572,10 @@ scope: architecture
 
 ### Growth capture
 
-- [ ] Evaluate “local semantic metadata + generated volatile views” for `/knowledge-capture` after implementation evidence exists.
-- [ ] Record the owner’s final symlink and descriptor-scope preferences in project memory if they recur outside this repository.
-- [ ] Update a skill only if execution reveals a reusable correction to planning, validation routing, or dependency-graph generation.
-- [ ] Log any user correction immediately in the observations ledger.
+- [x] Evaluate “local semantic metadata + generated volatile views” for `/knowledge-capture` after implementation evidence exists. — Evaluated 2026-08-23: one project-level sighting, below the three-sighting promotion threshold. Captured in the sibling notes' Growth Capture section and in the descriptor/catalog documentation rather than as a global rule.
+- [x] Record the owner’s final symlink and descriptor-scope preferences in project memory if they recur outside this repository. — Not recurred outside this repository as of 2026-08-23; ruling R1 (projection over symlink) and R4 (boundary-scoped lifecycle) are recorded in the sibling notes. Revives if a second repository needs the same projection decision.
+- [x] Update a skill only if execution reveals a reusable correction to planning, validation routing, or dependency-graph generation. — No skill changed. The eight deviations were plan-premise drift specific to this delivery, not reusable corrections to the planning or routing method.
+- [x] Log any user correction immediately in the observations ledger. — Logged: `~/.claude/observations.jsonl` carries the 2026-08-20 symlink convention entry and its 2026-08-23 supersession by the generated-projection ruling.
 
 ### Final validation sequence
 


### PR DESCRIPTION
## What

Closes out `semantic-module-governance-2026-08-21`. The work itself shipped in `6f4b2309` — every task row across Tiers 1–5 was already terminal, and the CHANGELOG entry landed with it. Only the plan artifact was left unfinalized.

| Change | Detail |
| --- | --- |
| `status: active` → `status: reference` | Plan and its implementation notes; matches the three sibling plans from the same initiative |
| `plans/features/` → `plans/reference/features/` | Recorded as pure renames; the notes' relative `plan:` reference still resolves since both co-moved |
| 4 growth-capture rows closed | Each now carries the evidence that already existed — observations-ledger entries for the symlink→projection correction, and the notes' single-sighting rulings |

## Why it sat open

`retire-done-plans` reported *"nothing to retire, no misclassified plans"* against it. Two separate reasons, worth separating:

1. While it was `status: active`, no frontmatter check could see it. Whether every task row is terminal is not readable from frontmatter.
2. Had it been set to `reference` **without** moving it, the tool would have detected the misfiled location — and still exited 0 under an `OK` banner.

(2) is fixed upstream in minipuft/repository-standards#15. Reaching this repo's CI needs a tagged release and a repin of the 6 `v1.3.0` references, which is a separate deliberate step.

## Verification

- `plans:retire:check` — passes.
- `plans:retire:self-test` — passes (102 tracked plans, link re-basing validated).
- Prettier — clean.
- `classify-validation-scope` routes to `docs`, the correct narrow scope; pre-commit ran and skipped typecheck accordingly.
- Replayed the pre-fix state against the patched upstream tool: exit 1, both files named.