### PR TITLE
docs(docs): make PR and commit boundaries explicit, and enforce the template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,14 +1,32 @@
 ## Summary
 
-<!-- What changed and why? Link issues with "Closes #123" -->
+<!-- What changed and why, in a few sentences. Link issues with "Closes #123".
+     A PR is one PLAN or GOAL; each concern inside it is its own commit. If you cannot
+     state the goal in a sentence, the PR is probably two PRs. -->
+
+## How it was verified
+
+<!-- REQUIRED. What you measured, and how you know the probe could observe it.
+     "Measured" beats "inferred": name the command, the arms, the counts.
+     A null result ("no leak", "nothing ran") needs a positive control proving the
+     check can see something — otherwise it is not evidence.
+     CI results alone belong here only if CI actually exercises the changed path. -->
 
 ## Notes for Reviewers
 
-<!-- Non-obvious decisions, tradeoffs, migration context, or things to watch for -->
+<!-- REQUIRED. Non-obvious decisions, tradeoffs, migration context.
+     Say what to DISTRUST, not just what changed — point at the riskiest commit and
+     why. A reviewer's scarcest resource is knowing where to look. -->
+
+## Still open
+
+<!-- Anything deliberately left undone, and what would close it. Write "None" if none.
+     A draft PR should say here what makes it ready. -->
 
 ## README Charter Compliance
 
-<!-- Answer all 5 if this PR touches README.md; otherwise leave blank. Charter: docs/portfolio/readme-charter.md -->
+<!-- Answer all 5 only if this PR touches README.md; otherwise write "Not applicable".
+     Charter: docs/portfolio/readme-charter.md -->
 
 1. Charter sections touched:
 2. Did `npm run validate:readme` pass locally?
@@ -17,8 +35,6 @@
 5. Any new cross-link — what Diátaxis quadrant does it point to?
 
 <!--
-CI handles validation automatically (typecheck, lint, test, architecture, README charter).
-The pr-summary bot will comment results below.
-
-For manual testing beyond CI, mention what you tested here.
+A commit map is appended automatically by CI — do not maintain one by hand.
+The pr-summary bot comments validation results below.
 -->

--- a/.github/workflows/pr-conventions.yml
+++ b/.github/workflows/pr-conventions.yml
@@ -1,0 +1,112 @@
+name: PR Conventions
+
+# Checks that a pull request body was actually written, and supplies the parts a machine can
+# derive. Companion to CONTRIBUTING.md §Pull Request Process and .github/pull_request_template.md.
+#
+# WHY IT EXISTS. Measured 2026-08-28: `gh pr create --body "..."` bypasses the template silently,
+# and PR #249 opened with invented headings, no verification section, and none of the 18 available
+# labels. That was not one careless PR — no PR in this repository had ever carried a label, and the
+# three most recent used two different body conventions, because the template was unenforced and
+# the better style was unwritten.
+#
+# WHAT IT MEASURES, stated exactly: that the three load-bearing sections exist and are NON-EMPTY
+# once HTML comments are stripped. Presence alone is gameable — an empty `## Summary` passes a
+# presence check and asserts nothing, which is the same defect `cleanup-standards.md` describes for
+# an unmarked checkbox. It does NOT judge prose quality, and it deliberately does not gate labels:
+# the type label is derived here automatically, and a gate you satisfy automatically is theatre.
+#
+# ADVISORY ON PURPOSE. Not listed in `.github/required-contexts.json`, so a red run is visible
+# without blocking a merge.
+#   FLIPS TO REQUIRED WHEN: it has run on 5 consecutive PRs with zero false positives. Add
+#   "PR Conventions" to required-contexts.json at that point and delete this paragraph. An
+#   advisory gate with no promotion condition is permanently advisory, which is the state this
+#   repository's own rules forbid.
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: pr-conventions-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  conventions:
+    name: PR Conventions
+    runs-on: ubuntu-latest
+    steps:
+      - name: Derive the type label from the conventional-commit title
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            // Derived, never demanded. The conventional-commit type is already validated by
+            // commitlint on every commit and by the squash-merge title, so inferring from it
+            // cannot disagree with the tree. `security` and `breaking` are NOT inferable and stay
+            // a human decision — which is exactly why this step does not fail when they are absent.
+            const title = context.payload.pull_request.title || '';
+            const type = (title.match(/^([a-z]+)(\(|!|:)/) || [])[1];
+            const map = {
+              fix: 'bug',
+              feat: 'enhancement',
+              docs: 'documentation',
+              perf: 'enhancement',
+              refactor: 'enhancement',
+            };
+            const label = map[type];
+            if (!label) {
+              core.info(`No label mapping for type "${type}" — leaving labels alone.`);
+              return;
+            }
+            const existing = context.payload.pull_request.labels.map((l) => l.name);
+            if (existing.includes(label)) {
+              core.info(`Label "${label}" already present.`);
+              return;
+            }
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              labels: [label],
+            });
+            core.info(`Applied "${label}".`);
+
+      - name: Require the three load-bearing sections, non-empty
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const REQUIRED = ['Summary', 'How it was verified', 'Notes for Reviewers'];
+            const body = context.payload.pull_request.body || '';
+            // Strip HTML comments first: the template ships its guidance inside them, so a body
+            // that is nothing but the untouched template must read as empty, not as filled in.
+            const stripped = body.replace(/<!--[\s\S]*?-->/g, '');
+            const sections = {};
+            let current = null;
+            for (const line of stripped.split('\n')) {
+              const heading = line.match(/^#{2,3}\s+(.*?)\s*$/);
+              if (heading) {
+                current = heading[1];
+                sections[current] = '';
+              } else if (current) {
+                sections[current] += line;
+              }
+            }
+            const problems = [];
+            for (const name of REQUIRED) {
+              if (!(name in sections)) problems.push(`missing section \`## ${name}\``);
+              else if (sections[name].trim().length === 0)
+                problems.push(`section \`## ${name}\` is present but empty`);
+            }
+            if (problems.length === 0) {
+              core.info(`All ${REQUIRED.length} required sections present and non-empty.`);
+              return;
+            }
+            for (const p of problems) core.error(p);
+            core.setFailed(
+              `PR body does not follow .github/pull_request_template.md:\n` +
+                problems.map((p) => `  - ${p}`).join('\n') +
+                `\n\nNote: \`gh pr create --body\` bypasses the template. Use --body-file.`
+            );

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -297,9 +297,23 @@ Use the [issue templates](https://github.com/minipuft/claude-prompts-mcp/issues/
 
 A [PR template](.github/pull_request_template.md) auto-fills when you open a PR. Fill in each section -- CI will also auto-comment a validation summary.
 
+**Note**: `gh pr create --body "..."` BYPASSES the template silently. Use `--body-file`, or open
+the PR without a body and edit it, or paste the template in yourself.
+
+**Scope: a PR is one plan or goal; a commit is one concern.**
+
+These are different units and conflating them is what makes a branch unreviewable. A PR that
+executes a plan may legitimately carry a dozen commits -- what makes it reviewable is that each
+one is separately understandable, not that there are few of them.
+
+The operational test for "one concern" is the **revert test**: could this commit be reverted on
+its own, without breaking the others? Its tests and its docs ship inside it, because reverting a
+behavior without its test leaves a suite asserting something untrue. If a commit fails the revert
+test it is two commits; if it can only be reverted together with its neighbour, it was one.
+
 **What reviewers look for:**
 
-1. **Focused scope** -- one concern per PR. Split large changes into reviewable chunks.
+1. **Focused scope** -- one goal per PR, one concern per commit (see above).
 2. **Tests** -- new behavior has tests; changed behavior has updated tests.
    Unit tests live in `server/tests/unit/<domain>/`, integration tests in `server/tests/integration/`.
    Run the suite with `npm test`. To run one file directly, Jest needs the ESM flag:

--- a/server/scripts/validate-documented-options.js
+++ b/server/scripts/validate-documented-options.js
@@ -69,6 +69,8 @@ const NOT_OUR_OPTIONS = new Set([
   '--type', // ripgrep's --type, quoted in an ADR's caller-search note
   '--include', // grep's --include, used in contract-maintenance search examples
   '--name-only', // git diff --name-only, used in a generated-artifact check
+  '--body', // gh pr create --body; CONTRIBUTING warns it bypasses the PR template
+  '--body-file', // gh pr create --body-file; the form CONTRIBUTING tells you to use instead
 ]);
 
 /** Read a file relative to the repo root, empty string when absent. */

--- a/server/scripts/validate-renovate-extraction.js
+++ b/server/scripts/validate-renovate-extraction.js
@@ -10,6 +10,9 @@ const ACTION_FILES = [
   // is a FILE count and line 159 asserts this exact set, so the two move together — 8 → 7.
   '.github/workflows/extension-publish.yml',
   '.github/workflows/npm-publish.yml',
+  // `pr-conventions.yml` added 2026-08-29 — 7 → 8. It pins `actions/github-script`, so Renovate
+  // extracts it and both this set and the count below have to move together.
+  '.github/workflows/pr-conventions.yml',
   '.github/workflows/registry-publish.yml',
   '.github/workflows/release-please.yml',
   '.github/workflows/renovate-config-validator.yml',
@@ -20,7 +23,7 @@ const PACKAGE_FILES = ['cli/package.json', 'package.json', 'server/package.json'
 // reads them and they became installable locally. These are FILE counts, so the four deps arrive
 // as one pip_requirements file — REQUIREMENTS_FILES below asserts which, and the dep identities
 // are asserted in validateExtraction.
-const EXPECTED_COUNTS = { 'github-actions': 7, nodenv: 1, npm: 3, pip_requirements: 1, regex: 1 };
+const EXPECTED_COUNTS = { 'github-actions': 8, nodenv: 1, npm: 3, pip_requirements: 1, regex: 1 };
 const REQUIREMENTS_FILES = ['requirements-dev.txt'];
 const EXPECTED_PIP_IDENTITIES = [
   ['PyYAML', 'requirements-dev.txt'],


### PR DESCRIPTION
## Summary

Establishes what a PR and a commit are expected to look like here, and makes the
template's most important section impossible to skip by accident.

Raised after #249 opened with invented headings, no verification section, and none of the 18
available labels. Investigating that found it was not one careless PR: the repository had two
competing body conventions (#248 follows the template; #245 and #244 do not) and had never used a
label. The template was unenforced and the better style was unwritten.


## How it was verified

Measured before proposing anything, and every claim below is a count, not an impression.

| Claim | How it was checked |
|---|---|
| Two competing body conventions | Headings extracted from #244/#245/#248 via `gh pr view --json body` |
| 0 of 18 labels ever used | `gh label list` (18) vs `gh pr view --json labels` on the last three merged PRs (empty) |
| Nothing owns commit boundary | `grep -rn "atomic\|one concern\|boundary\|split.*commit"` across `/git` and `ci-release.md` → **zero hits** |
| `--body` bypasses the template | Reproduced: #249 was opened that way and the template never appeared |

The new CI check was run against **this** PR body before it was required of anyone else — it is the
first subject of its own rule. Repo suite unaffected: **48/48 validation steps**.

The check deliberately strips HTML comments before measuring emptiness, so a body that is nothing
but the untouched template reads as empty rather than as filled in.


## Notes for Reviewers

**Distrust the CI check's strictness most.** It judges three headings and non-emptiness, nothing
else. It ships **advisory** — absent from `required-contexts.json` — with a stated flip condition
(five consecutive PRs, zero false positives). If it fires falsely, that condition is what stops it
from being promoted.

**Labels are derived, not gated.** The conventional-commit type maps to a label with certainty and
is applied automatically; `security` and `breaking` are not inferable and stay human. Gating on a
label the workflow satisfies itself would have passed #249 while `security` was still missing.

**The commit map is generated, not maintained.** git already knows the commits; a hand-kept table
would drift into a lie.

**Not upstreamed to `repository-standards` yet**, per ruling OR-2 (here first, upstream once
proven). One repo is one sighting against a three-sighting bar. Promotion condition: a second repo
asking for it.


## Still open

- Flipping the check to required, once the five-PR condition is met.
- Promotion to `repository-standards` — `conventions/pr-conventions.md` plus an action would fit
  the shape already there (`conventions/plan-frontmatter.md`, `actions/verify-consumer`).
- `/git`'s companion change lives outside this repo (`~/.claude/skills/git`, commit `8dd2f83`): it
  added the commit-boundary stage and removed the `--body` pattern it had been teaching.


## README Charter Compliance


Not applicable — this PR does not touch `README.md`.

