### PR TITLE
fix(tests): make the path-resolver test hermetic against the operator's environment

### DIFF
--- a/server/tests/unit/runtime/paths.runtime.test.ts
+++ b/server/tests/unit/runtime/paths.runtime.test.ts
@@ -1,16 +1,40 @@
-import { afterEach, describe, expect, it } from '@jest/globals';
+import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
 import path from 'node:path';
 
 import { PathResolver } from '../../../src/runtime/paths.js';
 
-const originalRuntimeRoot = process.env['MCP_RUNTIME_ROOT'];
-const originalWorkspace = process.env['MCP_WORKSPACE'];
+/**
+ * Every path override `PathResolver` honors, neutralized for the duration of this file.
+ *
+ * All four, not the two the assertions set. `MCP_RESOURCES_PATH` is exported into the shell by
+ * the Claude Code plugin that runs this very server, so on a maintainer's machine
+ * `getResourcesPath()` returned `~/.claude/resources` and the third assertion failed — while CI,
+ * where nothing exports it, stayed green. A test that passes only where the product is NOT
+ * installed is measuring the environment, not the resolver.
+ *
+ * Saved and restored rather than merely deleted: this process is shared with every other test
+ * file in the run.
+ */
+const PATH_ENV_KEYS = [
+  'MCP_RUNTIME_ROOT',
+  'MCP_WORKSPACE',
+  'MCP_RESOURCES_PATH',
+  'MCP_CONFIG_PATH',
+] as const;
+
+const originalPathEnv = new Map<string, string | undefined>(
+  PATH_ENV_KEYS.map((key) => [key, process.env[key]])
+);
+
+beforeEach(() => {
+  for (const key of PATH_ENV_KEYS) delete process.env[key];
+});
 
 afterEach(() => {
-  if (originalRuntimeRoot === undefined) delete process.env['MCP_RUNTIME_ROOT'];
-  else process.env['MCP_RUNTIME_ROOT'] = originalRuntimeRoot;
-  if (originalWorkspace === undefined) delete process.env['MCP_WORKSPACE'];
-  else process.env['MCP_WORKSPACE'] = originalWorkspace;
+  for (const [key, value] of originalPathEnv) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
 });
 
 describe('PathResolver writable runtime paths', () => {


### PR DESCRIPTION
## Summary

`PathResolver` honors four path overrides; `paths.runtime.test.ts` neutralized two.

The one that mattered is `MCP_RESOURCES_PATH`, which the Claude Code plugin exports into the shell
of anyone running this server. `getResourcesPath()` therefore returned `~/.claude/resources` instead
of the packaged path, and the assertion failed locally while CI — where nothing exports it — stayed
green. A test that passes only where the product is *not* installed is measuring the environment,
not the resolver.


## How it was verified

Falsified in both directions against a hostile environment, exporting all four overrides:

| Version | `MCP_RESOURCES_PATH=/totally/wrong` (+3 others) |
|---|---|
| Repaired | **3/3 pass** |
| Previous | **1/3 fails** |

So the repair is load-bearing and the failure it fixes is real, not a flake.

Full local run on this branch: **2729 unit · 740 integration · 151 e2e · 48/48 validation steps**.
The full suite matters here specifically — the env deletion is file-scoped, and the concern is
whether it leaks to siblings sharing the process. It does not; values are saved and restored rather
than deleted.

Attribution: reproduced on clean `origin/main` in a detached worktree before touching anything, so
this is not a regression from any open branch.


## Notes for Reviewers

**This is why it is worth fixing now rather than later.** `CLAUDE.md` was just changed to name
`npm run test:all` as the minimum before a commit. That command was unusable on any machine running
the plugin — so the guidance and the suite disagreed precisely on the machines that follow the
guidance.

**Restored, not just deleted.** `beforeEach` clears all four; `afterEach` puts back exactly what was
there. Deleting without restoring would have handed a mutated environment to every later test file
in the same worker.

Same shape as findings elsewhere in this repo's history: a green check that was green for a reason
unrelated to the property it claimed to measure — here inverted, red for an unrelated reason.


## Still open

None.


## README Charter Compliance


Not applicable — this PR does not touch `README.md`.

