### PR TITLE
ci(ci): a feat or fix PR must demonstrate its change

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,27 +1,39 @@
 ## Summary
 
-<!-- What changed and why, in a few sentences. Link issues with "Closes #123".
-     A PR is one PLAN or GOAL; each concern inside it is its own commit. If you cannot
-     state the goal in a sentence, the PR is probably two PRs. -->
+<!-- One sentence completing "After this merges, ___" — the OUTCOME, not the activity.
+     Then ≤5 bullets, each ONE consumer-observable change in ≤2 lines. Link the plan if
+     there is one (`plans/...`); do not re-tell it. Anything only a session participant
+     would understand belongs in the plan's implementation-notes, linked, not here.
+     A PR is one PLAN or GOAL; each concern inside it is its own commit. -->
+
+## Demonstration
+
+<!-- REQUIRED for feat / fix / perf / refactor — show it, do not describe it. Pick one:
+       · a tool-response transcript, BEFORE and AFTER, in fenced blocks (this server's screenshot)
+       · a ```mermaid``` stateDiagram / sequenceDiagram for a lifecycle or pipeline change
+       · a before/after table for a contract or output-shape change
+       · a screenshot or GIF when there is a UI or terminal to show
+     `verify-*.mjs` drives already emit transcripts — capture, do not paraphrase.
+     docs / chore / ci PRs may write `n/a: <reason>`. -->
 
 ## How it was verified
 
-<!-- REQUIRED. What you measured, and how you know the probe could observe it.
-     "Measured" beats "inferred": name the command, the arms, the counts.
-     A null result ("no leak", "nothing ran") needs a positive control proving the
-     check can see something — otherwise it is not evidence.
-     CI results alone belong here only if CI actually exercises the changed path. -->
+<!-- REQUIRED. A TABLE, not a count wall — one row per property:
+       | Claim | Probe (command) | Baseline → measured | Mutation that fails it |
+     A number without a baseline is noise; a null result ("no leak") needs the positive
+     control that proves the probe can see something. CI results belong here only if CI
+     actually exercises the changed path. -->
 
 ## Notes for Reviewers
 
-<!-- REQUIRED. Non-obvious decisions, tradeoffs, migration context.
-     Say what to DISTRUST, not just what changed — point at the riskiest commit and
-     why. A reviewer's scarcest resource is knowing where to look. -->
+<!-- REQUIRED. ≤3 pointers: the commit or file to DISTRUST and why. A reviewer's scarcest
+     resource is knowing where to look. No history here — a falsified ruling or a deviation
+     is a link to implementation-notes, not a paragraph. -->
 
 ## Still open
 
-<!-- Anything deliberately left undone, and what would close it. Write "None" if none.
-     A draft PR should say here what makes it ready. -->
+<!-- Plan row ids + links, one line each. Write "None" if none.
+     A draft PR says here what makes it ready. -->
 
 ## README Charter Compliance
 
@@ -35,6 +47,8 @@
 5. Any new cross-link — what Diátaxis quadrant does it point to?
 
 <!--
+Generate this skeleton pre-filled from your branch: `npm run pr:body -- --out /tmp/pr-body.md`
+(inside server/). Check it before opening: `node scripts/validate-pr-body.mjs --body-file /tmp/pr-body.md --title "<title>"`.
+The squash-merge commit carries THIS body, verbatim — it is what `git log` shows forever.
 A commit map is appended automatically by CI — do not maintain one by hand.
-The pr-summary bot comments validation results below.
 -->

--- a/.github/workflows/pr-conventions.yml
+++ b/.github/workflows/pr-conventions.yml
@@ -1,24 +1,32 @@
 name: PR Conventions
 
-# Checks that a pull request body was actually written, and supplies the parts a machine can
-# derive. Companion to CONTRIBUTING.md §Pull Request Process and .github/pull_request_template.md.
+# Checks that a pull request body was written FOR A READER, that its title is a conventional commit
+# the repo's own commitlint accepts, and supplies the parts a machine can derive. Companion to
+# CONTRIBUTING.md §Pull Request Process, .github/pull_request_template.md, and
+# scripts/validate-pr-body.mjs (which owns the body rules — this file only calls it).
 #
 # WHY IT EXISTS. Measured 2026-08-28: `gh pr create --body "..."` bypasses the template silently,
 # and PR #249 opened with invented headings, no verification section, and none of the 18 available
-# labels. That was not one careless PR — no PR in this repository had ever carried a label, and the
-# three most recent used two different body conventions, because the template was unenforced and
-# the better style was unwritten.
+# labels. Measured again 2026-09-01: #254 and #255 satisfied that check and were still unreadable —
+# 651 and 866 words of session-voice prose, no demonstration of a shipped state machine, a
+# verification section that was a count wall — and the squash-merge commit GitHub wrote for #254
+# concatenated 27 commit bodies into 4,615 words. Presence was never the property.
 #
-# WHAT IT MEASURES, stated exactly: that the three load-bearing sections exist and are NON-EMPTY
-# once HTML comments are stripped. Presence alone is gameable — an empty `## Summary` passes a
-# presence check and asserts nothing, which is the same defect `cleanup-standards.md` describes for
-# an unmarked checkbox. It does NOT judge prose quality, and it deliberately does not gate labels:
-# the type label is derived here automatically, and a gate you satisfy automatically is theatre.
+# WHAT IT MEASURES, stated exactly:
+#   · the three load-bearing sections exist and are NON-EMPTY once HTML comments are stripped;
+#   · `## Demonstration` is non-empty when the title's type is feat/fix/perf/refactor (`n/a: <why>`
+#     counts — the author must DECIDE, not decorate);
+#   · the title passes `commitlint` with commitlint.config.mjs — the same config every commit
+#     meets, so the squash-merge title (release-please's changelog line) cannot drift from it.
+#   Advisory warnings: body over 400 words; a verification section with no table or fenced block.
+#   It does NOT judge prose quality, and it deliberately does not gate labels: the type label is
+#   derived here automatically, and a gate you satisfy automatically is theatre.
 #
 # ADVISORY ON PURPOSE. Not listed in `.github/required-contexts.json`, so a red run is visible
 # without blocking a merge.
-#   FLIPS TO REQUIRED WHEN: it has run on 5 consecutive PRs with zero false positives. Add
-#   "PR Conventions" to required-contexts.json at that point and delete this paragraph. An
+#   FLIPS TO REQUIRED WHEN: it has run on 5 consecutive PRs with zero false positives, counted
+#   from the first PR opened after 2026-09-01 (the Demonstration and title checks reset the count).
+#   Add "PR Conventions" to required-contexts.json at that point and delete this paragraph. An
 #   advisory gate with no promotion condition is permanently advisory, which is the state this
 #   repository's own rules forbid.
 
@@ -74,39 +82,28 @@ jobs:
             });
             core.info(`Applied "${label}".`);
 
-      - name: Require the three load-bearing sections, non-empty
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          script: |
-            const REQUIRED = ['Summary', 'How it was verified', 'Notes for Reviewers'];
-            const body = context.payload.pull_request.body || '';
-            // Strip HTML comments first: the template ships its guidance inside them, so a body
-            // that is nothing but the untouched template must read as empty, not as filled in.
-            const stripped = body.replace(/<!--[\s\S]*?-->/g, '');
-            const sections = {};
-            let current = null;
-            for (const line of stripped.split('\n')) {
-              const heading = line.match(/^#{2,3}\s+(.*?)\s*$/);
-              if (heading) {
-                current = heading[1];
-                sections[current] = '';
-              } else if (current) {
-                sections[current] += line;
-              }
-            }
-            const problems = [];
-            for (const name of REQUIRED) {
-              if (!(name in sections)) problems.push(`missing section \`## ${name}\``);
-              else if (sections[name].trim().length === 0)
-                problems.push(`section \`## ${name}\` is present but empty`);
-            }
-            if (problems.length === 0) {
-              core.info(`All ${REQUIRED.length} required sections present and non-empty.`);
-              return;
-            }
-            for (const p of problems) core.error(p);
-            core.setFailed(
-              `PR body does not follow .github/pull_request_template.md:\n` +
-                problems.map((p) => `  - ${p}`).join('\n') +
-                `\n\nNote: \`gh pr create --body\` bypasses the template. Use --body-file.`
-            );
+          node-version-file: .node-version
+
+      - name: Prove the body check can fail (positive control)
+        run: node scripts/validate-pr-body.mjs --self-test
+
+      - name: Check the body against the template (scripts/validate-pr-body.mjs)
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: node scripts/validate-pr-body.mjs
+
+      - name: Lint the title with the repo's commitlint config
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        # Root package.json holds only commitlint + husky; `--ignore-scripts` skips the husky
+        # `prepare` step, which has nothing to wire on a CI checkout.
+        run: |
+          npm ci --ignore-scripts
+          printf '%s\n' "$PR_TITLE" | npx --no -- commitlint --verbose

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,8 @@ Both tool-surface changes alter the reachable-shape union of the MCP tool surfac
 
 ### Documentation
 
+- **PR bodies now show the change and squash merges carry the PR body, not every commit message.** The template gains a `## Demonstration` section (required for `feat`/`fix`/`perf`/`refactor`), verification is a claim-by-claim table, and `npm run pr:body` pre-fills the skeleton from the branch. `commitlint` warns on titles that name the session's activity instead of the merged outcome. -> `CONTRIBUTING.md` §Pull Request Process.
+
 - **`MCP_RUNTIME_ROOT` is documented where an operator reads.** It has always pinned `runtime-state/` and relative `logs/` independently of `MCP_WORKSPACE`, but appeared only in a source comment — absent from `--help` and from the handbook, whose "`MCP_WORKSPACE` (primary — SSOT for all paths)" was inaccurate. Setting `MCP_WORKSPACE` to a personal resource library and `MCP_RUNTIME_ROOT` elsewhere keeps `state.db` and logs where they were. `--help` also notes that overlay detection compares the workspace to the package root, so `MCP_RESOURCES_PATH` alone does not enable overlays.
 
 ## [4.0.1](https://github.com/minipuft/claude-prompts-mcp/compare/v4.0.0...v4.0.1) (2026-08-16)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -358,6 +358,28 @@ contract or output-shape change; a `vhs` GIF only when there is a terminal sessi
 the mutation that makes it fail. `2823 tests` with no baseline tells the reader nothing;
 `unit 2782 -> 2823 (+41)` does. A null result needs its positive control in the same row.
 
+#### Titles name the outcome
+
+The PR title becomes the squash-merge subject and the line release-please writes into the
+changelog. It is the one sentence most readers ever see, so it names what is TRUE AFTER MERGE, not
+what the session did. `commitlint` warns (never blocks) on the two most common misses.
+
+| Strategy                           | Test                                                                                                                     | Before -> after                                                                                   |
+| ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------- |
+| Outcome over activity              | Complete "After this merges, ___" with the subject                                                                       | `execute the security review` -> `refuse gate commands outside the operator's allowlist`          |
+| Release-notes test                 | Would it read correctly under **Fixed** / **Added** in a release?                                                        | `resource-surface consolidation` -> `resource writes land only inside the resource root`          |
+| State verbs over session verbs     | refuse · interrupt · require · carry · stop · bound -- not implement · execute · consolidate · update · improve · harden | `harden the HTTP transport` -> `reject requests the MCP spec forbids`                             |
+| One outcome                        | `and` or `-- a, b, and c` is two PRs, or one umbrella that has not been named                                            | `mid-chain unknown surfacing and adaptive consolidation` -> `blocking unknowns interrupt the run` |
+| No plan names                      | A plan name says what you were doing; the body links the plan                                                            | `execute plan 2A` -> `a paused run can be claimed by another client`                              |
+| Scope is where a reader would grep | The narrowest scope in `commitlint.config.mjs` the diff lives in                                                         | `fix(server)` -> `fix(gates)`                                                                     |
+| `!` names the consumer's move      | A breaking title says what the consumer must change                                                                      | `fix(gates)!: shell_command is an argv array; a string fails to load`                             |
+| Fits `git log --oneline`           | <=72 characters preferred; 100 enforced                                                                                  |                                                                                                   |
+
+Commit subjects follow the same rules one level down: the revert test (below) decides the
+boundary, and the subject names what is true after that one commit. A commit body past ~1,500
+characters is a plan note wearing a commit -- `commitlint` warns; move the reasoning to the
+implementation-notes and link it.
+
 **Scope: a PR is one plan or goal; a commit is one concern.**
 
 These are different units and conflating them is what makes a branch unreviewable. A PR that

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -295,10 +295,68 @@ Use the [issue templates](https://github.com/minipuft/claude-prompts-mcp/issues/
 
 ### Pull Request Process
 
-A [PR template](.github/pull_request_template.md) auto-fills when you open a PR. Fill in each section -- CI will also auto-comment a validation summary.
+A [PR template](.github/pull_request_template.md) auto-fills when you open a PR. Generate it
+pre-filled from your branch instead of typing into it -- the session that did the work should
+**edit** the reader's artifact, not author it from inside its own reasoning:
 
-**Note**: `gh pr create --body "..."` BYPASSES the template silently. Use `--body-file`, or open
-the PR without a body and edit it, or paste the template in yourself.
+```bash
+cd server
+npm run pr:body -- --out /tmp/pr-body.md           # skeleton: commit subjects, plan link, open rows, largest diffs
+$EDITOR /tmp/pr-body.md                              # fill every ___ and empty table cell
+node ../scripts/validate-pr-body.mjs --body-file /tmp/pr-body.md --title "feat(scope): outcome"
+gh pr create --title "feat(scope): outcome" --body-file /tmp/pr-body.md
+```
+
+**Note**: `gh pr create --body "..."` BYPASSES the template silently. Use `--body-file`.
+
+The `PR Conventions` workflow runs the same validator on every PR and lints the title with the
+repo's own `commitlint.config.mjs`. It is advisory until it has run clean on five consecutive PRs
+(the workflow header records the flip condition). CI also auto-comments a validation summary and
+the changed-file list -- never maintain those by hand.
+
+**The squash-merge commit carries the PR title and body, verbatim.** That is a repository setting
+(`squash_merge_commit_title: PR_TITLE`, `squash_merge_commit_message: PR_BODY`, set 2026-09-01).
+Before it, GitHub concatenated every commit body: #254 landed on `main` as a 4,615-word commit
+message. If the setting drifts, reapply it:
+
+```bash
+gh api -X PATCH repos/minipuft/claude-prompts-mcp \
+  -f squash_merge_commit_title=PR_TITLE -f squash_merge_commit_message=PR_BODY
+```
+
+#### Write for the reader, not the session
+
+Measured 2026-09-01 on #254 and #255: both PRs satisfied the template and were still unreadable at
+a glance -- 651 and 866 words, Summary bullets packing four facts each in plan-internal vocabulary
+(`OQ-A2b`, `stage 06 remains the single producer`), a verification section that was a wall of test
+counts with no baseline, and no demonstration of a feature that shipped a state machine. The
+CHANGELOG entry and every commit body were written at the same register. The defect was not the
+template; it was that one session wrote every artifact in its own voice.
+
+Each reader question has ONE owning artifact. The PR body **links** to the others; it never re-tells them.
+
+| The reader asks                                              | Owner                              | Voice                                                 |
+| ------------------------------------------------------------ | ---------------------------------- | ----------------------------------------------------- |
+| What can I now do / what no longer happens?                  | `CHANGELOG.md` `[Unreleased]`      | consumer; one behavior per bullet, two sentences max  |
+| Show me                                                      | PR body `## Demonstration`         | transcript, `mermaid`, before/after table, screenshot |
+| Where do I look, what do I distrust?                         | PR body `## Notes for Reviewers`   | reviewer; three pointers at most                      |
+| Why this diff?                                               | commit body                        | one concern; the why, not a restated diff             |
+| Why did the session decide X? Falsified rulings, deviations? | plan + `*-implementation-notes.md` | session voice -- this is where it belongs             |
+| Did CI run, which files changed?                             | bot comment                        | derived                                               |
+
+**Boundary test**: if a sentence only makes sense to someone who was in the session, it goes in the
+implementation-notes and the PR links it. Nothing is lost -- the notes are committed -- it is just not
+duplicated into an artifact built for a different reader.
+
+**Demonstrations for a headless server.** Images rarely apply here. What does: a tool-response
+transcript before and after (this server's screenshot -- the `verify-*.mjs` drives already emit
+them, capture rather than paraphrase); a ` ```mermaid ` `stateDiagram-v2` or `sequenceDiagram`
+for a lifecycle or pipeline change (GitHub renders it natively); a before/after table for a
+contract or output-shape change; a `vhs` GIF only when there is a terminal session worth watching.
+
+**Verification is a table.** One row per property: claim · probe command · baseline -> measured ·
+the mutation that makes it fail. `2823 tests` with no baseline tells the reader nothing;
+`unit 2782 -> 2823 (+41)` does. A null result needs its positive control in the same row.
 
 **Scope: a PR is one plan or goal; a commit is one concern.**
 
@@ -319,8 +377,9 @@ test it is two commits; if it can only be reverted together with its neighbour, 
    Run the suite with `npm test`. To run one file directly, Jest needs the ESM flag:
    `NODE_OPTIONS="--experimental-vm-modules" npx jest tests/unit/<path>`.
 3. **Docs updated** -- code and docs ship together.
-4. **Conventional commit** -- PR title follows commit conventions (squash-merge uses it).
-5. **Validation proof** -- link test output, screenshots, or describe manual verification steps.
+4. **Conventional commit** -- PR title follows commit conventions and names the outcome (squash-merge uses it).
+5. **Demonstration and measured verification** -- a transcript, diagram, or before/after table; a
+   verification table with baselines, not a count wall.
 6. **No regressions** -- hooks pass, CI green, no new lint violations.
 
 ## Git Hooks

--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -1,5 +1,67 @@
+/**
+ * Conventional-commit enforcement for every commit (commit-msg hook) AND every PR title
+ * (.github/workflows/pr-conventions.yml runs this same config on the title, because the
+ * squash-merge title is the line release-please writes into the changelog).
+ *
+ * Level 2 rules block. Level 1 rules WARN — they name a smell in the subject, and a smell is a
+ * question for the author, not a verdict. Scopes and header length stay blocking; keep the
+ * scope list in lockstep with CLAUDE.md and CONTRIBUTING.md.
+ *
+ * The three advisory subject rules encode CONTRIBUTING.md §Titles name the outcome:
+ *   subject-outcome-verb   — activity verbs ("implement", "execute", "consolidate", "update",
+ *                            "improve", "rework", "address", "refresh", "harden") describe the
+ *                            session; the subject should describe the product after merge.
+ *                            Measured 2026-09-01: "execute the security review" (#249),
+ *                            "resource-surface consolidation" (#255).
+ *   subject-one-outcome    — " and " or " — <list>" in a subject usually means two outcomes, which
+ *                            is two PRs (or one outcome that subsumes both and should be named).
+ *                            "#254: mid-chain unknown surfacing AND adaptive consolidation".
+ *   body-max-length        — a commit body past ~1,500 characters is a plan note wearing a commit;
+ *                            the reasoning belongs in implementation-notes, linked.
+ */
+
+const ACTIVITY_VERBS = [
+  'implement',
+  'execute',
+  'consolidate',
+  'consolidation',
+  'update',
+  'improve',
+  'rework',
+  'address',
+  'refresh',
+  'harden',
+  'enhance',
+  'misc',
+  'various',
+  'wip',
+];
+
+const activityVerb = new RegExp(`(^|\\s)(${ACTIVITY_VERBS.join('|')})(\\s|$)`, 'i');
+const secondOutcome = /\s(and|—|--)\s/;
+
 export default {
   extends: ['@commitlint/config-conventional'],
+  plugins: [
+    {
+      rules: {
+        'subject-outcome-verb': ({ subject }) => {
+          const hit = activityVerb.exec(subject || '');
+          return [
+            hit === null,
+            `subject uses the activity verb "${hit?.[2]}" — name the OUTCOME: what is true after this merges? (CONTRIBUTING.md §Titles name the outcome)`,
+          ];
+        },
+        'subject-one-outcome': ({ subject }) => {
+          const hit = secondOutcome.exec(subject || '');
+          return [
+            hit === null,
+            `subject joins two outcomes with "${hit?.[1]?.trim()}" — one PR is one outcome; name the one that subsumes both, or split (CONTRIBUTING.md §Titles name the outcome)`,
+          ];
+        },
+      },
+    },
+  ],
   rules: {
     'scope-enum': [
       2,
@@ -33,5 +95,8 @@ export default {
     ],
     'scope-empty': [0, 'never'],
     'header-max-length': [2, 'always', 100],
+    'subject-outcome-verb': [1, 'always'],
+    'subject-one-outcome': [1, 'always'],
+    'body-max-length': [1, 'always', 1500],
   },
 };

--- a/scripts/pr-body.mjs
+++ b/scripts/pr-body.mjs
@@ -1,0 +1,174 @@
+#!/usr/bin/env node
+/**
+ * Assembles a PR body skeleton from the branch, so the session that did the work EDITS the
+ * reader's artifact instead of authoring it from inside its own reasoning.
+ *
+ * WHY THIS EXISTS. Measured 2026-09-01 on #254 and #255: every downstream artifact — PR body,
+ * commit bodies, CHANGELOG entry, and the 4,615-word squash-merge message GitHub concatenated
+ * from 27 commit bodies — was written by the implementing session at the register of its own
+ * plan notes. The template was followed; the voice was wrong. The plan and its
+ * implementation-notes are already the committed home for that voice, so the fix is structural:
+ * derive what is derivable (commit subjects, the plan link, open rows, the largest diffs, the
+ * verify drives that changed), leave a hole where a human sentence is needed, and let the
+ * validator say when the holes are still holes.
+ *
+ * WHAT IT DERIVES, and from where:
+ *   Summary            commit subjects on the branch (one bullet each — trim, do not expand)
+ *                      + a link to the plan file the diff touches, if any
+ *   Demonstration      the `verify-*.mjs` drives the diff touched — capture their output
+ *   How it was verified table header + one row per changed test file as a candidate claim
+ *   Notes for Reviewers the three largest diffs on the branch, as distrust candidates
+ *   Still open         the plan's `☐` rows, one line each
+ *   README Charter     "Not applicable" unless README.md is in the diff
+ *
+ * The template file is the SSOT for headings and guidance: this script reads it and inserts
+ * under each heading, so it cannot disagree with what the validator checks.
+ *
+ * ZERO DEPENDENCIES. Node builtins and git only.
+ *
+ * Usage (inside server/):
+ *   npm run pr:body -- [--base origin/main] [--plan plans/x.md] [--out /tmp/pr-body.md]
+ */
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { checkBody } from './validate-pr-body.mjs';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const TEMPLATE = path.join(REPO_ROOT, '.github', 'pull_request_template.md');
+
+function git(...args) {
+  return execFileSync('git', args, { cwd: REPO_ROOT, encoding: 'utf8' }).trim();
+}
+
+function readArg(flag, fallback) {
+  const index = process.argv.indexOf(flag);
+  return index === -1 ? fallback : process.argv[index + 1];
+}
+
+/** Ranges are `base...HEAD` so a stale local base still measures only this branch. */
+function branchFacts(base) {
+  const range = `${base}...HEAD`;
+  const subjects = git('log', '--no-merges', '--format=%s', range).split('\n').filter(Boolean);
+  const files = git('diff', '--name-only', range).split('\n').filter(Boolean);
+  const numstat = git('diff', '--numstat', range)
+    .split('\n')
+    .filter(Boolean)
+    .map((line) => {
+      const [added, deleted, file] = line.split('\t');
+      return { file, churn: Number(added) + Number(deleted) || 0 };
+    })
+    .sort((a, b) => b.churn - a.churn);
+  return { subjects, files, numstat };
+}
+
+/** The plan is the first changed `plans/**` file that is not implementation notes. */
+function detectPlan(files, explicit) {
+  if (explicit) return explicit;
+  return files.find((f) => f.startsWith('plans/') && f.endsWith('.md') && !f.includes('implementation-notes'));
+}
+
+/** `☐` rows of a plan's markdown tables → `id — first words`. */
+function openRows(planPath) {
+  if (!planPath || !existsSync(path.join(REPO_ROOT, planPath))) return [];
+  const text = readFileSync(path.join(REPO_ROOT, planPath), 'utf8');
+  return text
+    .split('\n')
+    .filter((line) => line.startsWith('|') && line.includes('☐'))
+    .map((line) => {
+      const cells = line.split('|').map((c) => c.trim()).filter(Boolean);
+      return `${cells[0]} — ${(cells[1] || '').slice(0, 80)}`;
+    });
+}
+
+function summary({ subjects }, plan) {
+  const lines = ['After this merges, ___.', ''];
+  for (const s of subjects) lines.push(`- ${s}`);
+  if (plan) lines.push('', `Plan: \`${plan}\``);
+  return lines;
+}
+
+function demonstration({ files }) {
+  const drives = files.filter((f) => /verify-.*\.mjs$/.test(f));
+  if (drives.length === 0) return ['<!-- transcript / mermaid / before-after table, or `n/a: <reason>` -->'];
+  return ['Capture the output of:', '', ...drives.map((d) => `- \`node ${d.replace(/^server\//, '')}\``)];
+}
+
+function verified({ files }) {
+  const tests = files.filter((f) => /\.(test|spec)\.[cm]?[jt]s$/.test(f) || /^server\/scripts\/validate-/.test(f));
+  const rows = tests.length > 0 ? tests : ['<claim>'];
+  return [
+    '| Claim | Probe | Baseline → measured | Mutation that fails it |',
+    '| --- | --- | --- | --- |',
+    ...rows.map((t) => `| \`${t}\` | | | |`),
+  ];
+}
+
+function notes({ numstat }) {
+  return numstat.slice(0, 3).map((n) => `- \`${n.file}\` (${n.churn} lines changed) — distrust because ___`);
+}
+
+function stillOpen(plan) {
+  const rows = openRows(plan);
+  return rows.length === 0 ? ['None'] : rows.map((r) => `- ${r}`);
+}
+
+function readme({ files }) {
+  return files.includes('README.md') ? [] : ['Not applicable'];
+}
+
+/** Insert derived lines under each heading, after the template's own comment block. */
+function fill(template, sections) {
+  const out = [];
+  const lines = template.split('\n');
+  let pending = null;
+  let inComment = false;
+  for (const line of lines) {
+    out.push(line);
+    const heading = /^##\s+(.*?)\s*$/.exec(line);
+    if (heading) {
+      pending = sections[heading[1]] ?? null;
+      continue;
+    }
+    if (line.includes('<!--')) inComment = !line.includes('-->');
+    else if (inComment && line.includes('-->')) inComment = false;
+    else continue;
+    if (!inComment && pending) {
+      out.push('', ...pending);
+      pending = null;
+    }
+  }
+  return out.join('\n');
+}
+
+function main() {
+  const base = readArg('--base', 'origin/main');
+  const facts = branchFacts(base);
+  const plan = detectPlan(facts.files, readArg('--plan'));
+  const body = fill(readFileSync(TEMPLATE, 'utf8'), {
+    Summary: summary(facts, plan),
+    Demonstration: demonstration(facts),
+    'How it was verified': verified(facts),
+    'Notes for Reviewers': notes(facts),
+    'Still open': stillOpen(plan),
+    'README Charter Compliance': readme(facts),
+  });
+  const footer = `<!-- derived: ${facts.subjects.length} commits · ${facts.files.length} files · base ${base} -->`;
+  const result = `${body.trimEnd()}\n${footer}\n`;
+
+  const out = readArg('--out');
+  if (out) {
+    writeFileSync(out, result);
+    console.error(`wrote ${out}`);
+  } else {
+    process.stdout.write(result);
+  }
+  const { warnings } = checkBody(result, facts.subjects[0] ?? '');
+  for (const w of warnings) console.error(`note: ${w}`);
+  console.error('Fill every ___ and empty table cell; then: node scripts/validate-pr-body.mjs --body-file <file> --title "<title>"');
+}
+
+main();

--- a/scripts/validate-pr-body.mjs
+++ b/scripts/validate-pr-body.mjs
@@ -1,0 +1,218 @@
+#!/usr/bin/env node
+/**
+ * Checks that a pull-request body was written FOR A READER, not just written.
+ *
+ * WHY THIS EXISTS. The template has been enforced since #250 (2026-08-28): three sections must
+ * exist and be non-empty. Both #254 and #255 complied, and both were still unreadable at a glance —
+ * 651 and 866 words, Summary bullets packing four facts each in plan-internal vocabulary, a
+ * verification section that was a wall of test counts with no baseline, and no demonstration of a
+ * feature that shipped a state machine. Presence is not the property; the property is that a
+ * reader who was not in the session can see what changed. This script measures the parts of that
+ * a machine can measure, and no more.
+ *
+ * WHAT IT MEASURES, stated exactly:
+ *   FAIL  · `Summary`, `How it was verified`, `Notes for Reviewers` exist and are non-empty once
+ *           HTML comments are stripped (unchanged from the workflow's inline check it replaces).
+ *   FAIL  · `Demonstration` exists and is non-empty when the title's conventional-commit type is
+ *           feat / fix / perf / refactor. `n/a: <reason>` satisfies it — the point is that the
+ *           author DECIDED, not that every PR carries a diagram.
+ *   WARN  · body over WORD_BUDGET words. Length is a signal, not the test; a long body that is
+ *           all tables and transcripts is fine, and the warning says so.
+ *   WARN  · `How it was verified` carries no table and no fenced block — prose counts are the
+ *           shape the template forbids, but a probe listed as prose can still be a real probe.
+ *
+ * It does NOT judge prose quality, and it does not read the title beyond its type — the title is
+ * commitlint's job (the workflow runs commitlint on it with the repo's own config, so the two
+ * cannot drift).
+ *
+ * ZERO DEPENDENCIES, ON PURPOSE. The workflow runs this before any install so it works on the
+ * docs route, and `scripts/pr-body.mjs` imports `checkBody` so the generator and the gate share one
+ * definition of "ready".
+ *
+ * Usage:
+ *   node scripts/validate-pr-body.mjs --body-file <path> --title "<pr title>"
+ *   PR_BODY="..." PR_TITLE="..." node scripts/validate-pr-body.mjs
+ *   node scripts/validate-pr-body.mjs --self-test
+ */
+
+import { readFileSync } from 'node:fs';
+
+export const REQUIRED_SECTIONS = ['Summary', 'How it was verified', 'Notes for Reviewers'];
+export const DEMONSTRATION_SECTION = 'Demonstration';
+export const DEMONSTRATION_TYPES = new Set(['feat', 'fix', 'perf', 'refactor']);
+export const WORD_BUDGET = 400;
+
+/** `type(scope)!: subject` → `type`; null when the title is not conventional. */
+export function commitType(title) {
+  const match = /^([a-z]+)(?:\([^)]*\))?!?:/.exec(title || '');
+  return match ? match[1] : null;
+}
+
+/** Section name → body text, HTML comments stripped so an untouched template reads as empty. */
+export function splitSections(body) {
+  const stripped = (body || '').replace(/<!--[\s\S]*?-->/g, '');
+  const sections = {};
+  let current = null;
+  for (const line of stripped.split('\n')) {
+    const heading = /^#{2,3}\s+(.*?)\s*$/.exec(line);
+    if (heading) {
+      current = heading[1];
+      sections[current] = '';
+    } else if (current !== null) {
+      sections[current] += `${line}\n`;
+    }
+  }
+  return sections;
+}
+
+function isEmpty(text) {
+  return text === undefined || text.trim().length === 0;
+}
+
+/**
+ * @returns {{ failures: string[], warnings: string[] }}
+ */
+export function checkBody(body, title) {
+  const sections = splitSections(body);
+  const failures = [];
+  const warnings = [];
+
+  for (const name of REQUIRED_SECTIONS) {
+    if (!(name in sections)) failures.push(`missing section \`## ${name}\``);
+    else if (isEmpty(sections[name])) failures.push(`section \`## ${name}\` is present but empty`);
+  }
+
+  const type = commitType(title);
+  if (type !== null && DEMONSTRATION_TYPES.has(type)) {
+    if (!(DEMONSTRATION_SECTION in sections)) {
+      failures.push(
+        `\`## ${DEMONSTRATION_SECTION}\` is required for a \`${type}\` PR — show the change ` +
+          `(transcript, mermaid, before/after table) or write \`n/a: <reason>\``
+      );
+    } else if (isEmpty(sections[DEMONSTRATION_SECTION])) {
+      failures.push(
+        `\`## ${DEMONSTRATION_SECTION}\` is empty on a \`${type}\` PR — show the change or write \`n/a: <reason>\``
+      );
+    }
+  }
+
+  const words = Object.values(sections)
+    .join('\n')
+    .split(/\s+/)
+    .filter((w) => w.length > 0).length;
+  if (words > WORD_BUDGET) {
+    warnings.push(
+      `body is ${words} words (budget ${WORD_BUDGET}). Fine if it is tables and transcripts; ` +
+        `if it is prose, the session-voice parts belong in the plan's implementation-notes, linked.`
+    );
+  }
+
+  const verified = sections['How it was verified'];
+  if (!isEmpty(verified) && !/^\s*\|/m.test(verified) && !/```/.test(verified)) {
+    warnings.push(
+      '`## How it was verified` has no table and no fenced block — the template asks for one row ' +
+        'per claim (claim · probe · baseline → measured · mutation that fails it).'
+    );
+  }
+
+  return { failures, warnings };
+}
+
+function readArg(flag) {
+  const index = process.argv.indexOf(flag);
+  return index === -1 ? undefined : process.argv[index + 1];
+}
+
+function selfTest() {
+  const filled = [
+    '## Summary\n\nAfter this merges, x.\n',
+    '## Demonstration\n\n```\nbefore\n```\n',
+    '## How it was verified\n\n| Claim | Probe |\n|---|---|\n| a | b |\n',
+    '## Notes for Reviewers\n\nDistrust commit abc.\n',
+  ].join('\n');
+  const cases = [
+    {
+      name: 'filled feat body passes',
+      body: filled,
+      title: 'feat(chains): x',
+      expect: (r) => r.failures.length === 0,
+    },
+    {
+      name: 'untouched template reads as empty',
+      body: readFileSync(new URL('../.github/pull_request_template.md', import.meta.url), 'utf8'),
+      title: 'feat(chains): x',
+      expect: (r) => r.failures.length >= REQUIRED_SECTIONS.length,
+    },
+    {
+      name: 'feat without Demonstration fails',
+      body: filled.replace(/## Demonstration[\s\S]*?(?=## How)/, ''),
+      title: 'feat(chains): x',
+      expect: (r) => r.failures.some((f) => f.includes('Demonstration')),
+    },
+    {
+      name: 'docs without Demonstration passes',
+      body: filled.replace(/## Demonstration[\s\S]*?(?=## How)/, ''),
+      title: 'docs(docs): x',
+      expect: (r) => r.failures.length === 0,
+    },
+    {
+      name: 'n/a satisfies Demonstration',
+      body: filled.replace(/```\nbefore\n```/, 'n/a: config-only change'),
+      title: 'fix(ci): x',
+      expect: (r) => r.failures.length === 0,
+    },
+    {
+      name: 'over-budget body warns, does not fail',
+      body: filled.replace('After this merges, x.', 'word '.repeat(WORD_BUDGET + 1)),
+      title: 'feat(chains): x',
+      expect: (r) => r.failures.length === 0 && r.warnings.some((w) => w.includes('budget')),
+    },
+    {
+      name: 'prose verification warns',
+      body: filled.replace(/\| Claim \| Probe \|\n\|---\|---\|\n\| a \| b \|/, 'ran the suite, 2823 passed'),
+      title: 'feat(chains): x',
+      expect: (r) => r.warnings.some((w) => w.includes('no table')),
+    },
+  ];
+  let failed = 0;
+  for (const c of cases) {
+    const result = checkBody(c.body, c.title);
+    const ok = c.expect(result);
+    console.log(`${ok ? 'PASS' : 'FAIL'}  ${c.name}`);
+    if (!ok) {
+      failed += 1;
+      console.log(`      ${JSON.stringify(result)}`);
+    }
+  }
+  return failed === 0;
+}
+
+function main() {
+  if (process.argv.includes('--self-test')) {
+    process.exit(selfTest() ? 0 : 1);
+  }
+  const bodyFile = readArg('--body-file');
+  const body = bodyFile ? readFileSync(bodyFile, 'utf8') : (process.env.PR_BODY ?? '');
+  const title = readArg('--title') ?? process.env.PR_TITLE ?? '';
+  const { failures, warnings } = checkBody(body, title);
+  const ci = process.env.GITHUB_ACTIONS === 'true';
+
+  for (const w of warnings) console.log(ci ? `::warning::${w}` : `warning: ${w}`);
+  for (const f of failures) console.log(ci ? `::error::${f}` : `error: ${f}`);
+
+  if (failures.length > 0) {
+    console.log(
+      `\nPR body does not follow .github/pull_request_template.md.` +
+        `\nNote: \`gh pr create --body\` bypasses the template. Generate one: npm run pr:body -- --out /tmp/pr-body.md`
+    );
+    process.exit(1);
+  }
+  console.log(
+    `PR body: ${REQUIRED_SECTIONS.length} required sections present, ` +
+      `${warnings.length === 0 ? 'no warnings' : `${warnings.length} warning(s)`}.`
+  );
+}
+
+if (process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).href) {
+  main();
+}

--- a/server/package.json
+++ b/server/package.json
@@ -180,6 +180,7 @@
     "validate:spawn-input-guards": "node scripts/validate-spawn-input-guards.js",
     "validate:no-phantom-columns:self-test": "tsx scripts/validate-no-phantom-columns.ts --self-test",
     "worktree:create": "node ../scripts/create-worktree.js",
+    "pr:body": "node ../scripts/pr-body.mjs",
     "validate:git-hooks-active": "node scripts/validate-git-hooks-active.js",
     "validate:git-hooks-active:self-test": "node scripts/validate-git-hooks-active.js --self-test",
     "validate:hooks-registered": "node ../scripts/validate-hook-registration.js",

--- a/server/scripts/validate-documented-options.js
+++ b/server/scripts/validate-documented-options.js
@@ -60,6 +60,7 @@ const NOT_OUR_OPTIONS = new Set([
   '--write', // prettier --write
   '--access', // npm publish --access public
   '--tags', // git push --tags
+  '--oneline', // git log --oneline (CONTRIBUTING §Titles name the outcome)
   '--title', // gh release create
   '--notes', // gh release create
   '--plugin-dir', // claude --plugin-dir


### PR DESCRIPTION
## Summary

After this merges, a `feat`/`fix` PR without a demonstration fails `PR Conventions`, the squash-merge commit on `main` is the PR title + body instead of every commit message, and commitlint warns on a title that names what the session did rather than what changed.

- `## Demonstration` section in the template; `## How it was verified` is a claim-per-row table.
- `scripts/validate-pr-body.mjs` owns the body rules; the workflow calls it (after its `--self-test`) and lints the title with `commitlint.config.mjs`.
- `npm run pr:body` pre-fills the skeleton from the branch — commit subjects, plan link, open `☐` rows, largest diffs.
- Two advisory commitlint rules (`subject-outcome-verb`, `subject-one-outcome`) and a 1,500-char `body-max-length` warning.
- Repo setting flipped to `PR_TITLE` / `PR_BODY` for squash merges (documented in `CONTRIBUTING.md` with the reapply command).

Motivation and the reader/session boundary: `CONTRIBUTING.md` §Write for the reader, not the session.

## Demonstration

The new commitlint rules on three real titles (warn, never block):

```
$ printf '%s\n' "feat(chains): mid-chain unknown surfacing and adaptive consolidation" | npx commitlint
⚠  subject uses the activity verb "consolidation" — name the OUTCOME: what is true after this merges?  [subject-outcome-verb]
⚠  subject joins two outcomes with "and" — one PR is one outcome; name the one that subsumes both, or split  [subject-one-outcome]
⚠  found 0 problems, 2 warnings

$ printf '%s\n' "fix(server)!: execute the security review — bound every path from authored content to code" | npx commitlint
⚠  subject uses the activity verb "execute" …  [subject-outcome-verb]
⚠  subject joins two outcomes with "—" …        [subject-one-outcome]

$ printf '%s\n' "feat(chains): blocking unknowns interrupt the run instead of bending it" | npx commitlint
(clean)
```

The body gate, before and after, on the same untouched template:

| | `main` (inline check) | this branch (`validate-pr-body.mjs`) |
| --- | --- | --- |
| Untouched template | 3 × "present but empty" | same 3, plus `## Demonstration` required for a `feat` |
| `feat` body, no Demonstration | passes | **fails**: "show the change or write `n/a: <reason>`" |
| 650-word prose body | passes silently | passes with `::warning::` naming the budget and where the prose belongs |
| Verification as a count wall | passes silently | passes with `::warning::` asking for the table |

## How it was verified

| Claim | Probe | Baseline → measured | Mutation that fails it |
| --- | --- | --- | --- |
| The body gate can fail | `node scripts/validate-pr-body.mjs --self-test` | 7/7 cases, incl. untouched template and feat-without-Demonstration | any case's `expect` inverted → FAIL line |
| The workflow runs the same code | `pr-conventions.yml` `run: node scripts/validate-pr-body.mjs` with `PR_BODY`/`PR_TITLE` env | inline JS → one script, self-test step first | delete the self-test step → the gate has no positive control |
| Title rules fire on the real offenders | `printf <title> \| npx commitlint` on #249, #254, #255 titles | 0 warnings → 2 warnings each; outcome-shaped title stays 0 | remove a verb from `ACTIVITY_VERBS` → its title goes quiet |
| The generator runs on a branch, not just compiles | `npm run pr:body -- --out /tmp/pr-skeleton.md` on this branch | 2 commit subjects as bullets, 0 open rows (no plan), 3 largest diffs as distrust candidates, `derived: 2 commits · 10 files` | — |
| Nothing else regressed | `npm run validate:all` in the worktree | 53/53 (one new `--oneline` exception in `validate:documented-options`, reason inline) | remove the exception → `validate:documented-options` red |
| Squash merges carry the PR body | `gh api repos/minipuft/claude-prompts-mcp --jq '{squash_merge_commit_title,squash_merge_commit_message}'` | `COMMIT_OR_PR_TITLE`/`COMMIT_MESSAGES` → `PR_TITLE`/`PR_BODY` | not code; reapply command in CONTRIBUTING |

## Notes for Reviewers

- `commitlint.config.mjs` `ACTIVITY_VERBS` — the list is a judgment call; `harden` and `refresh` are the two most likely false positives. Advisory, so a wrong entry costs a warning, not a block.
- `pr-conventions.yml` now checks out and runs `npm ci --ignore-scripts` at the root (3 devDeps) to lint the title. The advisory-to-required counter resets from this PR; the header says so.
- `scripts/validate-pr-body.mjs` Demonstration rule keys on the **title's** type only. A `docs` PR that ships behavior is not caught — by design; the title is the contract.

## Still open

None

## README Charter Compliance

Not applicable
