### PR TITLE
ci(ci): the PR body becomes an enforced two-register document

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,18 +1,16 @@
 ## Summary
 
 <!-- One sentence completing "After this merges, ___" — the OUTCOME, not the activity.
-     Then ≤5 bullets, each ONE consumer-observable change in ≤2 lines. Link the plan if
-     there is one (`plans/...`); do not re-tell it. Anything only a session participant
-     would understand belongs in the plan's implementation-notes, linked, not here.
-     A PR is one PLAN or GOAL; each concern inside it is its own commit. -->
+     Then ≤5 bullets, each ONE consumer-observable change in ≤2 lines. No plan vocabulary or
+     row ids anywhere in the body: the `Plan:` footer (bottom) is the only sanctioned plan
+     mention, and session reasoning lives in the implementation-notes or the collapsed
+     Appendix. A PR is one PLAN or GOAL; each concern inside it is its own commit. -->
 
 ## Demonstration
 
-<!-- REQUIRED for feat / fix / perf / refactor — show it, do not describe it. Pick one:
-       · a tool-response transcript, BEFORE and AFTER, in fenced blocks (this server's screenshot)
-       · a ```mermaid``` stateDiagram / sequenceDiagram for a lifecycle or pipeline change
-       · a before/after table for a contract or output-shape change
-       · a screenshot or GIF when there is a UI or terminal to show
+<!-- REQUIRED for feat / fix / perf / refactor — show the CONSUMER-OBSERVABLE DELTA: the surface
+     someone actually touches (tool response, CLI output, refusal message, lifecycle), BEFORE and
+     AFTER, one screen max. Forms by how they age: fenced transcript > mermaid > table > image.
      `verify-*.mjs` drives already emit transcripts — capture, do not paraphrase.
      docs / chore / ci PRs may write `n/a: <reason>`. -->
 
@@ -21,19 +19,17 @@
 <!-- REQUIRED. A TABLE, not a count wall — one row per property:
        | Claim | Probe (command) | Baseline → measured | Mutation that fails it |
      A number without a baseline is noise; a null result ("no leak") needs the positive
-     control that proves the probe can see something. CI results belong here only if CI
-     actually exercises the changed path. -->
+     control that proves the probe can see something. An unfilled row fails the gate. -->
 
 ## Notes for Reviewers
 
 <!-- REQUIRED. ≤3 pointers: the commit or file to DISTRUST and why. A reviewer's scarcest
-     resource is knowing where to look. No history here — a falsified ruling or a deviation
-     is a link to implementation-notes, not a paragraph. -->
+     resource is knowing where to look. History and rationale go in the Appendix, not here. -->
 
 ## Still open
 
-<!-- Plan row ids + links, one line each. Write "None" if none.
-     A draft PR says here what makes it ready. -->
+<!-- Remaining work in plain reader terms, one line each; write "None" if none.
+     No plan row ids — and note the Plan footer contract below. -->
 
 ## README Charter Compliance
 
@@ -47,8 +43,18 @@
 5. Any new cross-link — what Diátaxis quadrant does it point to?
 
 <!--
-Generate this skeleton pre-filled from your branch: `npm run pr:body -- --out /tmp/pr-body.md`
-(inside server/). Check it before opening: `node scripts/validate-pr-body.mjs --body-file /tmp/pr-body.md --title "<title>"`.
-The squash-merge commit carries THIS body, verbatim — it is what `git log` shows forever.
+TWO-REGISTER BODY. Reader voice above; below, an optional collapsed archive:
+  <details><summary>Appendix — session archive</summary> … </details>
+The appendix (deviation log excerpts, captured drive transcripts, extended verification) is
+exempt from the word budget and — because squash merges carry the PR body — lands greppable
+in main's history. The generator seeds it from your implementation-notes.
+
+PLAN FOOTER CONTRACT. If this PR executes a plan, end the body with exactly one line:
+  Plan: `plans/<path>.md`
+The gate FAILS while that plan's `status:` is non-final — finalize (every row terminal,
+retired) in this same PR. No other plan mention belongs in the body.
+
+Generate this skeleton pre-filled: `npm run pr:body -- --out /tmp/pr-body.md` (inside server/).
+Check before opening: `node scripts/validate-pr-body.mjs --body-file /tmp/pr-body.md --title "<title>"`.
 A commit map is appended automatically by CI — do not maintain one by hand.
 -->

--- a/.github/required-contexts.json
+++ b/.github/required-contexts.json
@@ -2,7 +2,7 @@
   "$comment": [
     "SSOT for the status checks required to merge into `main`.",
     "GitHub matches a required context against a check-run NAME, which is a job's `name:`",
-    "field — not its job id. Writing the id produces a context nothing ever reports, and every",
+    "field \u2014 not its job id. Writing the id produces a context nothing ever reports, and every",
     "PR then blocks with all checks green. That is exactly what happened here: protection",
     "required [\"lint\",\"build\"] while CI reported `Lint & Validate` and `Build`.",
     "",
@@ -14,5 +14,11 @@
     "    --input -"
   ],
   "branch": "main",
-  "contexts": ["Lint & Validate", "CLI", "Build", "Test Suite"]
+  "contexts": [
+    "Lint & Validate",
+    "CLI",
+    "Build",
+    "Test Suite",
+    "PR Conventions"
+  ]
 }

--- a/.github/workflows/pr-conventions.yml
+++ b/.github/workflows/pr-conventions.yml
@@ -22,13 +22,19 @@ name: PR Conventions
 #   It does NOT judge prose quality, and it deliberately does not gate labels: the type label is
 #   derived here automatically, and a gate you satisfy automatically is theatre.
 #
-# ADVISORY ON PURPOSE. Not listed in `.github/required-contexts.json`, so a red run is visible
-# without blocking a merge.
-#   FLIPS TO REQUIRED WHEN: it has run on 5 consecutive PRs with zero false positives, counted
-#   from the first PR opened after 2026-09-01 (the Demonstration and title checks reset the count).
-#   Add "PR Conventions" to required-contexts.json at that point and delete this paragraph. An
-#   advisory gate with no promotion condition is permanently advisory, which is the state this
-#   repository's own rules forbid.
+# REQUIRED SINCE 2026-09-02 (listed in `.github/required-contexts.json`). The original flip
+# condition — five consecutive clean PRs, zero false positives — was dropped by an operator
+# ruling: it had no counter and no detector (the exact "retirability without detection" failure
+# cleanup-standards.md names), and it was unsatisfiable anyway, because every renovate and
+# release-please PR failed the body check from the day the gate existed (#252, #253 probed
+# FAILURE 2026-09-01). Bot PRs are now exempt from the authored-body checks — their bodies and
+# titles are machine-owned surface — which removes the known false-positive sources; a wrong
+# failure after this is a defect to fix, not a count to reset.
+#
+# This workflow also asserts the merge-settings contract (squash carries PR_TITLE + PR_BODY,
+# branches delete on merge): those are repository SETTINGS, invisible to any file-based gate,
+# and the two-register body design depends on them — the collapsed appendix reaches main's
+# history only because the squash body does.
 
 on:
   pull_request:
@@ -82,6 +88,32 @@ jobs:
             });
             core.info(`Applied "${label}".`);
 
+      - name: Assert the merge-settings contract still holds
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const { data } = await github.rest.repos.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            });
+            const expected = {
+              squash_merge_commit_title: 'PR_TITLE',
+              squash_merge_commit_message: 'PR_BODY',
+              delete_branch_on_merge: true,
+            };
+            const drifted = Object.entries(expected).filter(([k, v]) => data[k] !== v);
+            if (drifted.length === 0) {
+              core.info('Merge settings match the contract.');
+              return;
+            }
+            for (const [k, v] of drifted) core.error(`${k} is ${data[k]}, expected ${v}`);
+            core.setFailed(
+              'Repository merge settings drifted from the two-register body contract. Reapply:\n' +
+                '  gh api -X PATCH repos/' + context.repo.owner + '/' + context.repo.repo + ' \\\n' +
+                '    -f squash_merge_commit_title=PR_TITLE -f squash_merge_commit_message=PR_BODY \\\n' +
+                '    -F delete_branch_on_merge=true'
+            );
+
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -91,15 +123,18 @@ jobs:
           node-version-file: .node-version
 
       - name: Prove the body check can fail (positive control)
+        if: github.event.pull_request.user.type != 'Bot'
         run: node scripts/validate-pr-body.mjs --self-test
 
       - name: Check the body against the template (scripts/validate-pr-body.mjs)
+        if: github.event.pull_request.user.type != 'Bot'
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: node scripts/validate-pr-body.mjs
 
       - name: Lint the title with the repo's commitlint config
+        if: github.event.pull_request.user.type != 'Bot'
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
         # Root package.json holds only commitlint + husky; `--ignore-scripts` skips the husky

--- a/.github/workflows/pr-conventions.yml
+++ b/.github/workflows/pr-conventions.yml
@@ -31,10 +31,10 @@ name: PR Conventions
 # titles are machine-owned surface — which removes the known false-positive sources; a wrong
 # failure after this is a defect to fix, not a count to reset.
 #
-# This workflow also asserts the merge-settings contract (squash carries PR_TITLE + PR_BODY,
-# branches delete on merge): those are repository SETTINGS, invisible to any file-based gate,
-# and the two-register body design depends on them — the collapsed appendix reaches main's
-# history only because the squash body does.
+# This workflow also asserts the merge-settings contract by its EFFECT (the newest squash on
+# main carries a PR-shaped body): the settings are invisible to any file-based gate AND to the
+# workflow token, and the two-register body design depends on them — the collapsed appendix
+# reaches main's history only because the squash body does.
 
 on:
   pull_request:
@@ -88,27 +88,37 @@ jobs:
             });
             core.info(`Applied "${label}".`);
 
-      - name: Assert the merge-settings contract still holds
+      - name: Assert the merge-settings contract by its effect
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
-            const { data } = await github.rest.repos.get({
+            // The merge-settings fields on repos.get are visible only to admin tokens, and the
+            // workflow GITHUB_TOKEN is not one — probed 2026-09-02 on #259, where all three
+            // fields read `undefined` and the first version of this step failed on its own PR.
+            // A probe that cannot observe must not stand as a gate, so assert the EFFECT the
+            // contract exists for: the newest squash merge on the default branch must carry a
+            // PR-shaped body (PR_BODY squash opens with a `## ` heading). Detection lags by one
+            // merge — the best a non-admin observer can do, and it fires before the NEXT merge
+            // compounds the drift. delete_branch_on_merge has no non-admin observable and is
+            // deliberately not asserted; it is convenience, not contract.
+            const { data: commits } = await github.rest.repos.listCommits({
               owner: context.repo.owner,
               repo: context.repo.repo,
+              per_page: 20,
             });
-            const expected = {
-              squash_merge_commit_title: 'PR_TITLE',
-              squash_merge_commit_message: 'PR_BODY',
-              delete_branch_on_merge: true,
-            };
-            const drifted = Object.entries(expected).filter(([k, v]) => data[k] !== v);
-            if (drifted.length === 0) {
-              core.info('Merge settings match the contract.');
+            const squash = commits.find((c) => /\(#\d+\)$/.test(c.commit.message.split('\n')[0]));
+            if (!squash) {
+              core.info('No squash-shaped commit in the last 20 on the default branch.');
               return;
             }
-            for (const [k, v] of drifted) core.error(`${k} is ${data[k]}, expected ${v}`);
+            const body = squash.commit.message.split('\n').slice(1).join('\n');
+            if (/^## /m.test(body)) {
+              core.info(`Squash ${squash.sha.slice(0, 8)} carries a PR-shaped body — contract holds.`);
+              return;
+            }
             core.setFailed(
-              'Repository merge settings drifted from the two-register body contract. Reapply:\n' +
+              `Squash commit ${squash.sha.slice(0, 8)} does not carry the PR body — the ` +
+                'squash_merge_commit_message setting has drifted from PR_BODY. Reapply:\n' +
                 '  gh api -X PATCH repos/' + context.repo.owner + '/' + context.repo.repo + ' \\\n' +
                 '    -f squash_merge_commit_title=PR_TITLE -f squash_merge_commit_message=PR_BODY \\\n' +
                 '    -F delete_branch_on_merge=true'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,7 @@ Both tool-surface changes alter the reachable-shape union of the MCP tool surfac
 ### Documentation
 
 - **PR bodies now show the change and squash merges carry the PR body, not every commit message.** The template gains a `## Demonstration` section (required for `feat`/`fix`/`perf`/`refactor`), verification is a claim-by-claim table, and `npm run pr:body` pre-fills the skeleton from the branch. `commitlint` warns on titles that name the session's activity instead of the merged outcome. -> `CONTRIBUTING.md` §Pull Request Process.
+- **The PR body is now a two-register document and its gate blocks merges.** Reader voice above the fold; a collapsed `<details>` appendix carries the session archive (deviations, captured transcripts) into `main`'s history via the squash body. `PR Conventions` is a required check -- bot PRs exempt -- and a `Plan:` footer refuses to merge until the named plan is finalized.
 
 - **`MCP_RUNTIME_ROOT` is documented where an operator reads.** It has always pinned `runtime-state/` and relative `logs/` independently of `MCP_WORKSPACE`, but appeared only in a source comment — absent from `--help` and from the handbook, whose "`MCP_WORKSPACE` (primary — SSOT for all paths)" was inaccurate. Setting `MCP_WORKSPACE` to a personal resource library and `MCP_RUNTIME_ROOT` elsewhere keeps `state.db` and logs where they were. `--help` also notes that overlay detection compares the workspace to the package root, so `MCP_RESOURCES_PATH` alone does not enable overlays.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -310,18 +310,42 @@ gh pr create --title "feat(scope): outcome" --body-file /tmp/pr-body.md
 **Note**: `gh pr create --body "..."` BYPASSES the template silently. Use `--body-file`.
 
 The `PR Conventions` workflow runs the same validator on every PR and lints the title with the
-repo's own `commitlint.config.mjs`. It is advisory until it has run clean on five consecutive PRs
-(the workflow header records the flip condition). CI also auto-comments a validation summary and
-the changed-file list -- never maintain those by hand.
+repo's own `commitlint.config.mjs`. It is a **required** context (since 2026-09-02) on every
+non-bot PR; bot PRs (renovate, release-please) are exempt from the authored-body checks because
+their bodies are machine-owned. The validator fails on surviving `___` placeholders, unfilled
+verification rows, and a non-finalized `Plan:` footer. CI also auto-comments a validation summary
+and the changed-file list -- never maintain those by hand.
+
+**The body is a two-register document.** Reader voice above the fold (the 400-word budget counts
+only this -- fenced blocks, tables, and `<details>` content are exempt); below it, an optional
+collapsed appendix:
+
+```markdown
+<details><summary>Appendix -- session archive (not review material)</summary>
+ ... deviation-log excerpts, captured drive transcripts, extended verification ...
+</details>
+```
+
+Because the squash commit carries the PR body, the appendix lands **greppable in main's history**
+-- it replaces the per-commit bodies squash discards. `npm run pr:body` seeds it from your
+implementation-notes' `## Deviations`. Commit bodies are therefore ephemeral working notes: keep
+them one-concern and short (commitlint warns past 1,500 characters).
+
+**Plan footer contract.** A PR executing a plan ends its body with exactly one line --
+`` Plan: `plans/<path>.md` `` -- and mentions the plan nowhere else (no row ids, no plan
+vocabulary). The gate fails while that plan's `status:` is non-final: finalize the plan (every
+row terminal, retired) in the same PR, or the PR does not merge.
 
 **The squash-merge commit carries the PR title and body, verbatim.** That is a repository setting
-(`squash_merge_commit_title: PR_TITLE`, `squash_merge_commit_message: PR_BODY`, set 2026-09-01).
+(`squash_merge_commit_title: PR_TITLE`, `squash_merge_commit_message: PR_BODY`, set 2026-09-01;
+`delete_branch_on_merge: true`, set 2026-09-02).
 Before it, GitHub concatenated every commit body: #254 landed on `main` as a 4,615-word commit
-message. If the setting drifts, reapply it:
+message. The `PR Conventions` workflow asserts these settings on every PR; if they drift, reapply:
 
 ```bash
 gh api -X PATCH repos/minipuft/claude-prompts-mcp \
-  -f squash_merge_commit_title=PR_TITLE -f squash_merge_commit_message=PR_BODY
+  -f squash_merge_commit_title=PR_TITLE -f squash_merge_commit_message=PR_BODY \
+  -F delete_branch_on_merge=true
 ```
 
 #### Write for the reader, not the session
@@ -335,14 +359,14 @@ template; it was that one session wrote every artifact in its own voice.
 
 Each reader question has ONE owning artifact. The PR body **links** to the others; it never re-tells them.
 
-| The reader asks                                              | Owner                              | Voice                                                 |
-| ------------------------------------------------------------ | ---------------------------------- | ----------------------------------------------------- |
-| What can I now do / what no longer happens?                  | `CHANGELOG.md` `[Unreleased]`      | consumer; one behavior per bullet, two sentences max  |
-| Show me                                                      | PR body `## Demonstration`         | transcript, `mermaid`, before/after table, screenshot |
-| Where do I look, what do I distrust?                         | PR body `## Notes for Reviewers`   | reviewer; three pointers at most                      |
-| Why this diff?                                               | commit body                        | one concern; the why, not a restated diff             |
-| Why did the session decide X? Falsified rulings, deviations? | plan + `*-implementation-notes.md` | session voice -- this is where it belongs             |
-| Did CI run, which files changed?                             | bot comment                        | derived                                               |
+| The reader asks                                              | Owner                                                                          | Voice                                                 |
+| ------------------------------------------------------------ | ------------------------------------------------------------------------------ | ----------------------------------------------------- |
+| What can I now do / what no longer happens?                  | `CHANGELOG.md` `[Unreleased]`                                                  | consumer; one behavior per bullet, two sentences max  |
+| Show me                                                      | PR body `## Demonstration`                                                     | transcript, `mermaid`, before/after table, screenshot |
+| Where do I look, what do I distrust?                         | PR body `## Notes for Reviewers`                                               | reviewer; three pointers at most                      |
+| Why this diff?                                               | commit body                                                                    | one concern; the why, not a restated diff             |
+| Why did the session decide X? Falsified rulings, deviations? | plan + `*-implementation-notes.md`, excerpted into the PR's collapsed Appendix | session voice -- collapsed, never above the fold      |
+| Did CI run, which files changed?                             | bot comment                                                                    | derived                                               |
 
 **Boundary test**: if a sentence only makes sense to someone who was in the session, it goes in the
 implementation-notes and the PR links it. Nothing is lost -- the notes are committed -- it is just not

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -340,7 +340,8 @@ row terminal, retired) in the same PR, or the PR does not merge.
 (`squash_merge_commit_title: PR_TITLE`, `squash_merge_commit_message: PR_BODY`, set 2026-09-01;
 `delete_branch_on_merge: true`, set 2026-09-02).
 Before it, GitHub concatenated every commit body: #254 landed on `main` as a 4,615-word commit
-message. The `PR Conventions` workflow asserts these settings on every PR; if they drift, reapply:
+message. The `PR Conventions` workflow asserts their effect on every PR (the newest squash on
+`main` must carry a PR-shaped body); if they drift, reapply:
 
 ```bash
 gh api -X PATCH repos/minipuft/claude-prompts-mcp \

--- a/scripts/pr-body.mjs
+++ b/scripts/pr-body.mjs
@@ -84,17 +84,19 @@ function openRows(planPath) {
     });
 }
 
-function summary({ subjects }, plan) {
+function summary({ subjects }) {
   const lines = ['After this merges, ___.', ''];
   for (const s of subjects) lines.push(`- ${s}`);
-  if (plan) lines.push('', `Plan: \`${plan}\``);
   return lines;
 }
 
 function demonstration({ files }) {
   const drives = files.filter((f) => /verify-.*\.mjs$/.test(f));
-  if (drives.length === 0) return ['<!-- transcript / mermaid / before-after table, or `n/a: <reason>` -->'];
-  return ['Capture the output of:', '', ...drives.map((d) => `- \`node ${d.replace(/^server\//, '')}\``)];
+  const lines = ['**Before**', '', '```', '___', '```', '', '**After**', '', '```', '___', '```'];
+  if (drives.length > 0) {
+    lines.push('', 'Capture from:', ...drives.map((d) => `- \`node ${d.replace(/^server\//, '')}\``));
+  }
+  return lines;
 }
 
 function verified({ files }) {
@@ -113,11 +115,38 @@ function notes({ numstat }) {
 
 function stillOpen(plan) {
   const rows = openRows(plan);
-  return rows.length === 0 ? ['None'] : rows.map((r) => `- ${r}`);
+  if (rows.length === 0) return ['None'];
+  return [
+    '___',
+    '',
+    '<!-- open rows at generation time — the Plan footer gate refuses to merge until the plan is',
+    '     finalized, so close or kill these in this PR:',
+    ...rows.map((r) => `       ${r}`),
+    '-->',
+  ];
 }
 
 function readme({ files }) {
   return files.includes('README.md') ? [] : ['Not applicable'];
+}
+
+/** The collapsed archive register: Deviations excerpts from any implementation-notes in the diff. */
+function appendix({ files }) {
+  const notes = files.filter((f) => f.endsWith('implementation-notes.md'));
+  const parts = ['<details>', '<summary>Appendix — session archive (not review material)</summary>', ''];
+  for (const n of notes) {
+    const notePath = path.join(REPO_ROOT, n);
+    if (!existsSync(notePath)) continue;
+    const deviations = /## Deviations[\s\S]*?(?=\n## |$)/.exec(readFileSync(notePath, 'utf8'));
+    if (deviations) parts.push(`From \`${n}\`:`, '', deviations[0].trim(), '');
+  }
+  parts.push(
+    '<!-- captured drive transcripts, extended verification, deviation detail — collapsed content',
+    '     is exempt from the word budget and lands greppable on main via the squash body -->',
+    '',
+    '</details>'
+  );
+  return parts;
 }
 
 /** Insert derived lines under each heading, after the template's own comment block. */
@@ -149,15 +178,18 @@ function main() {
   const facts = branchFacts(base);
   const plan = detectPlan(facts.files, readArg('--plan'));
   const body = fill(readFileSync(TEMPLATE, 'utf8'), {
-    Summary: summary(facts, plan),
+    Summary: summary(facts),
     Demonstration: demonstration(facts),
     'How it was verified': verified(facts),
     'Notes for Reviewers': notes(facts),
     'Still open': stillOpen(plan),
     'README Charter Compliance': readme(facts),
   });
-  const footer = `<!-- derived: ${facts.subjects.length} commits · ${facts.files.length} files · base ${base} -->`;
-  const result = `${body.trimEnd()}\n${footer}\n`;
+  const tail = [''];
+  if (plan) tail.push(`Plan: \`${plan}\``, '');
+  tail.push(...appendix(facts), '');
+  tail.push(`<!-- derived: ${facts.subjects.length} commits · ${facts.files.length} files · base ${base} -->`);
+  const result = `${body.trimEnd()}\n${tail.join('\n')}\n`;
 
   const out = readArg('--out');
   if (out) {

--- a/scripts/validate-pr-body.mjs
+++ b/scripts/validate-pr-body.mjs
@@ -16,18 +16,32 @@
  *   FAIL  · `Demonstration` exists and is non-empty when the title's conventional-commit type is
  *           feat / fix / perf / refactor. `n/a: <reason>` satisfies it — the point is that the
  *           author DECIDED, not that every PR carries a diagram.
- *   WARN  · body over WORD_BUDGET words. Length is a signal, not the test; a long body that is
- *           all tables and transcripts is fine, and the warning says so.
- *   WARN  · `How it was verified` carries no table and no fenced block — prose counts are the
- *           shape the template forbids, but a probe listed as prose can still be a real probe.
+ *   FAIL  · a `___` placeholder survives outside HTML comments — the `pr:body` skeleton seeds
+ *           them, so a surviving one means the body was generated and never edited. Without this
+ *           rule the generator+gate pair would MINT a new theatre path: a body that passes while
+ *           saying nothing (ruled 2026-09-02, blind-spot pass).
+ *   FAIL  · a row of the verification table has every cell after the first empty — the skeleton's
+ *           unfilled shape, same reasoning as the placeholder rule.
+ *   FAIL  · a `Plan:` footer names a plan whose frontmatter `status:` is still non-final
+ *           (active / backlog / proposal / draft / loaded / reserved), or names a file that does
+ *           not exist at this checkout. Ruled 2026-09-02: the footer is a CONTRACT, not a
+ *           pointer — a PR carrying a plan does not merge until that plan is finalized in it.
+ *           The footer is also the ONLY sanctioned plan mention; row ids and plan vocabulary in
+ *           the body are the session voice this whole file exists to keep out.
+ *   WARN  · above-the-fold text over WORD_BUDGET words. Fenced blocks, tables, and everything
+ *           inside `<details>` are NOT counted: the body is a two-register document (reader voice
+ *           above the fold, collapsed archive appendix below), and the budget bounds only the
+ *           part a reader must traverse. The first version counted transcripts and warned
+ *           hardest on the most compliant PRs — the advisory-rot path.
+ *   WARN  · `How it was verified` carries no table and no fenced block.
  *
  * It does NOT judge prose quality, and it does not read the title beyond its type — the title is
  * commitlint's job (the workflow runs commitlint on it with the repo's own config, so the two
  * cannot drift).
  *
  * ZERO DEPENDENCIES, ON PURPOSE. The workflow runs this before any install so it works on the
- * docs route, and `scripts/pr-body.mjs` imports `checkBody` so the generator and the gate share one
- * definition of "ready".
+ * docs route, and `scripts/pr-body.mjs` imports `checkBody` so the generator and the gate share
+ * one definition of "ready".
  *
  * Usage:
  *   node scripts/validate-pr-body.mjs --body-file <path> --title "<pr title>"
@@ -35,12 +49,26 @@
  *   node scripts/validate-pr-body.mjs --self-test
  */
 
-import { readFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 export const REQUIRED_SECTIONS = ['Summary', 'How it was verified', 'Notes for Reviewers'];
 export const DEMONSTRATION_SECTION = 'Demonstration';
 export const DEMONSTRATION_TYPES = new Set(['feat', 'fix', 'perf', 'refactor']);
 export const WORD_BUDGET = 400;
+/** Non-final plan statuses; anything else (reference, done, complete, closed…) is final. */
+export const NON_FINAL_STATUSES = new Set([
+  'active',
+  'backlog',
+  'proposal',
+  'draft',
+  'loaded',
+  'reserved',
+]);
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 
 /** `type(scope)!: subject` → `type`; null when the title is not conventional. */
 export function commitType(title) {
@@ -48,12 +76,15 @@ export function commitType(title) {
   return match ? match[1] : null;
 }
 
+function stripComments(text) {
+  return (text || '').replace(/<!--[\s\S]*?-->/g, '');
+}
+
 /** Section name → body text, HTML comments stripped so an untouched template reads as empty. */
 export function splitSections(body) {
-  const stripped = (body || '').replace(/<!--[\s\S]*?-->/g, '');
   const sections = {};
   let current = null;
-  for (const line of stripped.split('\n')) {
+  for (const line of stripComments(body).split('\n')) {
     const heading = /^#{2,3}\s+(.*?)\s*$/.exec(line);
     if (heading) {
       current = heading[1];
@@ -69,44 +100,89 @@ function isEmpty(text) {
   return text === undefined || text.trim().length === 0;
 }
 
-/**
- * @returns {{ failures: string[], warnings: string[] }}
- */
-export function checkBody(body, title) {
-  const sections = splitSections(body);
-  const failures = [];
-  const warnings = [];
+/** Reader-facing words only: drop <details> archives, fenced blocks, and table rows. */
+function aboveTheFoldWords(body) {
+  const visible = stripComments(body)
+    .replace(/<details>[\s\S]*?<\/details>/gi, '')
+    .replace(/```[\s\S]*?```/g, '')
+    .split('\n')
+    .filter((line) => !line.trimStart().startsWith('|'))
+    .join('\n');
+  return visible.split(/\s+/).filter((w) => w.length > 0).length;
+}
 
+function checkRequiredSections(sections, failures) {
   for (const name of REQUIRED_SECTIONS) {
     if (!(name in sections)) failures.push(`missing section \`## ${name}\``);
     else if (isEmpty(sections[name])) failures.push(`section \`## ${name}\` is present but empty`);
   }
+}
 
+function checkDemonstration(sections, title, failures) {
   const type = commitType(title);
-  if (type !== null && DEMONSTRATION_TYPES.has(type)) {
-    if (!(DEMONSTRATION_SECTION in sections)) {
+  if (type === null || !DEMONSTRATION_TYPES.has(type)) return;
+  const section = sections[DEMONSTRATION_SECTION];
+  if (section === undefined || isEmpty(section)) {
+    failures.push(
+      `\`## ${DEMONSTRATION_SECTION}\` is required for a \`${type}\` PR — show the consumer-` +
+        `observable delta (transcript, mermaid, before/after table) or write \`n/a: <reason>\``
+    );
+  }
+}
+
+function checkPlaceholders(body, failures) {
+  if (/___/.test(stripComments(body))) {
+    failures.push(
+      'a `___` placeholder survives — the generated skeleton was not filled in. Every `___` is a ' +
+        'sentence the reader needed.'
+    );
+  }
+}
+
+function checkVerificationRows(sections, failures) {
+  const verified = sections['How it was verified'];
+  if (isEmpty(verified)) return;
+  for (const line of verified.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith('|') || /^\|[\s|:-]+\|$/.test(trimmed)) continue;
+    const cells = trimmed.split('|').slice(1, -1).map((c) => c.trim());
+    if (cells.length >= 2 && !isEmpty(cells[0]) && cells.slice(1).every(isEmpty)) {
       failures.push(
-        `\`## ${DEMONSTRATION_SECTION}\` is required for a \`${type}\` PR — show the change ` +
-          `(transcript, mermaid, before/after table) or write \`n/a: <reason>\``
-      );
-    } else if (isEmpty(sections[DEMONSTRATION_SECTION])) {
-      failures.push(
-        `\`## ${DEMONSTRATION_SECTION}\` is empty on a \`${type}\` PR — show the change or write \`n/a: <reason>\``
+        `verification row \`${cells[0].slice(0, 60)}\` has no probe, baseline, or mutation — an ` +
+          'unfilled skeleton row is a claim without evidence'
       );
     }
   }
+}
 
-  const words = Object.values(sections)
-    .join('\n')
-    .split(/\s+/)
-    .filter((w) => w.length > 0).length;
-  if (words > WORD_BUDGET) {
-    warnings.push(
-      `body is ${words} words (budget ${WORD_BUDGET}). Fine if it is tables and transcripts; ` +
-        `if it is prose, the session-voice parts belong in the plan's implementation-notes, linked.`
+function checkPlanFooter(body, failures, repoRoot) {
+  const match = /^Plan:\s*`?(plans\/\S+?)`?\s*$/m.exec(stripComments(body));
+  if (!match) return;
+  const planPath = path.join(repoRoot, match[1]);
+  if (!existsSync(planPath)) {
+    failures.push(`\`Plan:\` footer names \`${match[1]}\`, which does not exist at this checkout`);
+    return;
+  }
+  const status = /^status:\s*(\S+)/m.exec(readFileSync(planPath, 'utf8'))?.[1]?.toLowerCase();
+  if (status === undefined) {
+    failures.push(`\`Plan:\` footer names \`${match[1]}\`, which declares no \`status:\``);
+  } else if (NON_FINAL_STATUSES.has(status)) {
+    failures.push(
+      `\`Plan:\` footer names \`${match[1]}\` with status \`${status}\` — a PR carrying a plan ` +
+        'merges only once that plan is finalized (retired with every row terminal) in this same PR'
     );
   }
+}
 
+function collectWarnings(body, sections) {
+  const warnings = [];
+  const words = aboveTheFoldWords(body);
+  if (words > WORD_BUDGET) {
+    warnings.push(
+      `above-the-fold text is ${words} words (budget ${WORD_BUDGET}; transcripts, tables and ` +
+        '<details> are not counted). Move prose into the collapsed appendix or the implementation-notes.'
+    );
+  }
   const verified = sections['How it was verified'];
   if (!isEmpty(verified) && !/^\s*\|/m.test(verified) && !/```/.test(verified)) {
     warnings.push(
@@ -114,8 +190,22 @@ export function checkBody(body, title) {
         'per claim (claim · probe · baseline → measured · mutation that fails it).'
     );
   }
+  return warnings;
+}
 
-  return { failures, warnings };
+/**
+ * @returns {{ failures: string[], warnings: string[] }}
+ */
+export function checkBody(body, title, options = {}) {
+  const repoRoot = options.repoRoot ?? REPO_ROOT;
+  const sections = splitSections(body);
+  const failures = [];
+  checkRequiredSections(sections, failures);
+  checkDemonstration(sections, title, failures);
+  checkPlaceholders(body, failures);
+  checkVerificationRows(sections, failures);
+  checkPlanFooter(body, failures, repoRoot);
+  return { failures, warnings: collectWarnings(body, sections) };
 }
 
 function readArg(flag) {
@@ -123,23 +213,28 @@ function readArg(flag) {
   return index === -1 ? undefined : process.argv[index + 1];
 }
 
+function selfTestFixtures() {
+  const root = mkdtempSync(path.join(tmpdir(), 'pr-body-selftest-'));
+  mkdirSync(path.join(root, 'plans'), { recursive: true });
+  writeFileSync(path.join(root, 'plans', 'active.md'), '---\nstatus: active\n---\n');
+  writeFileSync(path.join(root, 'plans', 'retired.md'), '---\nstatus: reference\n---\n');
+  return root;
+}
+
 function selfTest() {
+  const root = selfTestFixtures();
   const filled = [
     '## Summary\n\nAfter this merges, x.\n',
     '## Demonstration\n\n```\nbefore\n```\n',
     '## How it was verified\n\n| Claim | Probe |\n|---|---|\n| a | b |\n',
     '## Notes for Reviewers\n\nDistrust commit abc.\n',
   ].join('\n');
+  const noFail = (r) => r.failures.length === 0;
   const cases = [
-    {
-      name: 'filled feat body passes',
-      body: filled,
-      title: 'feat(chains): x',
-      expect: (r) => r.failures.length === 0,
-    },
+    { name: 'filled feat body passes', body: filled, title: 'feat(chains): x', expect: noFail },
     {
       name: 'untouched template reads as empty',
-      body: readFileSync(new URL('../.github/pull_request_template.md', import.meta.url), 'utf8'),
+      body: readFileSync(path.join(REPO_ROOT, '.github', 'pull_request_template.md'), 'utf8'),
       title: 'feat(chains): x',
       expect: (r) => r.failures.length >= REQUIRED_SECTIONS.length,
     },
@@ -153,30 +248,78 @@ function selfTest() {
       name: 'docs without Demonstration passes',
       body: filled.replace(/## Demonstration[\s\S]*?(?=## How)/, ''),
       title: 'docs(docs): x',
-      expect: (r) => r.failures.length === 0,
+      expect: noFail,
     },
     {
       name: 'n/a satisfies Demonstration',
       body: filled.replace(/```\nbefore\n```/, 'n/a: config-only change'),
       title: 'fix(ci): x',
-      expect: (r) => r.failures.length === 0,
+      expect: noFail,
     },
     {
-      name: 'over-budget body warns, does not fail',
-      body: filled.replace('After this merges, x.', 'word '.repeat(WORD_BUDGET + 1)),
+      name: 'surviving ___ placeholder fails',
+      body: filled.replace('After this merges, x.', 'After this merges, ___.'),
       title: 'feat(chains): x',
-      expect: (r) => r.failures.length === 0 && r.warnings.some((w) => w.includes('budget')),
+      expect: (r) => r.failures.some((f) => f.includes('placeholder')),
+    },
+    {
+      name: 'placeholder inside a comment is fine',
+      body: filled.replace('After this merges, x.', 'After this merges, x. <!-- fill ___ -->'),
+      title: 'feat(chains): x',
+      expect: noFail,
+    },
+    {
+      name: 'unfilled verification row fails',
+      body: filled.replace('| a | b |', '| `tests/x.test.ts` |  |'),
+      title: 'feat(chains): x',
+      expect: (r) => r.failures.some((f) => f.includes('verification row')),
+    },
+    {
+      name: 'active plan footer fails',
+      body: `${filled}\nPlan: \`plans/active.md\`\n`,
+      title: 'feat(chains): x',
+      expect: (r) => r.failures.some((f) => f.includes('finalized')),
+    },
+    {
+      name: 'retired plan footer passes',
+      body: `${filled}\nPlan: \`plans/retired.md\`\n`,
+      title: 'feat(chains): x',
+      expect: noFail,
+    },
+    {
+      name: 'dangling plan footer fails',
+      body: `${filled}\nPlan: \`plans/gone.md\`\n`,
+      title: 'feat(chains): x',
+      expect: (r) => r.failures.some((f) => f.includes('does not exist')),
+    },
+    {
+      name: 'prose over budget warns, transcripts and details do not count',
+      body:
+        filled.replace('After this merges, x.', `${'word '.repeat(WORD_BUDGET + 1)}`) +
+        `\n<details><summary>appendix</summary>\n\n${'archive '.repeat(2000)}\n</details>\n`,
+      title: 'feat(chains): x',
+      expect: (r) =>
+        noFail(r) && r.warnings.filter((w) => w.includes('budget')).length === 1,
+    },
+    {
+      name: 'details-only bulk stays under budget',
+      body: `${filled}\n<details><summary>appendix</summary>\n\n${'archive '.repeat(2000)}\n</details>\n`,
+      title: 'feat(chains): x',
+      expect: (r) => noFail(r) && !r.warnings.some((w) => w.includes('budget')),
     },
     {
       name: 'prose verification warns',
-      body: filled.replace(/\| Claim \| Probe \|\n\|---\|---\|\n\| a \| b \|/, 'ran the suite, 2823 passed'),
+      body: filled.replace(
+        /\| Claim \| Probe \|\n\|---\|---\|\n\| a \| b \|/,
+        'ran the suite, 2823 passed'
+      ),
       title: 'feat(chains): x',
       expect: (r) => r.warnings.some((w) => w.includes('no table')),
     },
   ];
   let failed = 0;
   for (const c of cases) {
-    const result = checkBody(c.body, c.title);
+    const result = checkBody(c.body, c.title, { repoRoot: root });
     const ok = c.expect(result);
     console.log(`${ok ? 'PASS' : 'FAIL'}  ${c.name}`);
     if (!ok) {


### PR DESCRIPTION
## Summary

After this merges, a PR body is a two-register document — reader voice above the fold, a collapsed session archive below it that squash carries greppable onto `main` — and the gate that enforces it blocks merges.

- The validator fails on surviving `triple-underscore` placeholders, unfilled verification rows, and a `Plan:` footer naming a non-finalized plan (the footer is now the only sanctioned plan mention, and it is a contract: finalize the plan in the same PR or don't merge).
- The 400-word budget counts only above-the-fold prose; fenced blocks, tables, and `<details>` are exempt.
- `npm run pr:body` seeds a consumer before/after Demonstration, the appendix from implementation-notes `## Deviations`, and the plan footer.
- `PR Conventions` is now in `required-contexts.json`; bot PRs (renovate, release-please) skip the authored-body checks, and a new step asserts the merge-settings contract (`PR_TITLE`/`PR_BODY` squash, `delete_branch_on_merge`) the design depends on.

## Demonstration

The generator's unedited skeleton, before and after this change, against the gate:

```
$ node scripts/validate-pr-body.mjs --body-file skeleton.md --title "feat(chains): x"
BEFORE (#257 rules):  PR body: 3 required sections present, 1 warning(s).   ← lazy fill PASSES
AFTER  (this PR):     error: a placeholder survives — the generated skeleton was not filled in.
                      error: verification row `tests/x.test.ts` has no probe, baseline, or mutation
```

A PR pointing at an unfinished plan:

```
$ printf '## Summary\n…\nPlan: `plans/features/x.md`\n' > body.md   # plan status: active
AFTER: error: `Plan:` footer names `plans/features/x.md` with status `active` — a PR carrying a
       plan merges only once that plan is finalized in this same PR
```

## How it was verified

| Claim | Probe | Baseline → measured | Mutation that fails it |
| --- | --- | --- | --- |
| Every new rule can fail | `node scripts/validate-pr-body.mjs --self-test` | 7 → 14 cases, all PASS (placeholder, unfilled row, active/dangling/retired plan footer, details-exempt budget) | invert any case's `expect` |
| Generator emits the new shape | `npm run pr:body` on this branch | skeleton carries Before/After blocks, `<details>` appendix, no plan link in Summary | — |
| Workflow stays well-formed and pinned | `yaml.safe_load` + `validate:github-action-pins` + `validate:required-contexts` | 47 pins OK; 5 required contexts resolve to job names (was 4) | rename the job → required-contexts red |
| Bot exemption is real | `if: user.type != 'Bot'` on the three authored-body steps | renovate #252/#253 were FAILURE under the old gate | drop the `if` → next renovate PR goes red |
| Settings drift is detected | the assert step runs on this very PR | `delete_branch_on_merge` flipped true before push; step green | flip a setting back → this PR's gate goes red |
| Nothing else regressed | `npm run validate:all` in the worktree | 53/53 | — |

## Notes for Reviewers

- `NON_FINAL_STATUSES` in `scripts/validate-pr-body.mjs` — the plans tree uses 11 status spellings; I enumerated the non-final six rather than the final ones, so an unknown new status defaults to *passing*. Distrust that choice if you'd rather fail-closed.
- The workflow header rewrite drops the five-clean-PRs flip condition by ruling; the reasoning lives in the header itself.
- `checkVerificationRows` treats any `|`-led line in the section as a table row; an exotic markdown table could false-positive — the self-test covers the shapes the generator emits, not all of markdown.

## Still open

None

## README Charter Compliance

Not applicable

<details>
<summary>Appendix — session archive (not review material)</summary>

Decided by operator interview 2026-09-02 (three rounds, /unknowns Move 3): plan mentions = one footer link with a finalize-before-merge contract; merge shape = squash everywhere + this appendix pattern (chosen over hybrid merge commits and kept-branches once `<details>` + `PR_BODY` squash was shown to land the archive on `main`); demonstration = delta-first, any form, transcript preferred; gate = required now, counter ceremony dropped as detectorless and unsatisfiable (bot PRs were red since #250). The prior five-clean-PRs condition was written 2026-09-01 by the same rework that shipped the gate; its falsifier (a false positive) existed from birth in the form of renovate #252/#253.

</details>
