### PR TITLE
fix(tests): the flaky e2e suite waits for its server before deleting its workspace

### DIFF
--- a/server/tests/e2e/bundled-resource-fallback.e2e.test.ts
+++ b/server/tests/e2e/bundled-resource-fallback.e2e.test.ts
@@ -140,7 +140,7 @@ describe('a workspace resource directory overlays the bundled tree (P1.0a)', () 
   }, 120_000);
 
   afterAll(async () => {
-    if (workspace) await rm(workspace, { recursive: true, force: true });
+    if (workspace) await rm(workspace, { recursive: true, force: true, maxRetries: 5 });
   });
 
   it('starts, rather than dying on a bundled framework the workspace does not carry', () => {

--- a/server/tests/e2e/resource-write-destination.e2e.test.ts
+++ b/server/tests/e2e/resource-write-destination.e2e.test.ts
@@ -123,8 +123,19 @@ class ProbeServer {
     };
   }
 
-  stop(): void {
-    this.proc?.kill();
+  /**
+   * `kill()` only SIGNALS; it does not wait. Returning immediately let the workspace `rm` race
+   * the server's own log flush, so teardown failed with `ENOTEMPTY: rmdir '<ws>/logs'` on the
+   * first CI runs of #257 and #259 while every assertion had passed. Same fix as
+   * resource-path-containment's ProbeServer; the timeout keeps a wedged child from hanging.
+   */
+  async stop(): Promise<void> {
+    if (this.proc === undefined || this.proc.exitCode !== null) return;
+    await new Promise<void>((resolve) => {
+      this.proc.once('exit', () => resolve());
+      this.proc.kill();
+      setTimeout(resolve, 5_000);
+    });
   }
 }
 
@@ -147,8 +158,8 @@ describe('resource writes resolve through PathResolver (D8 Arc 1)', () => {
   }, 120_000);
 
   afterAll(async () => {
-    server?.stop();
-    if (workspace) await rm(workspace, { recursive: true, force: true });
+    await server?.stop();
+    if (workspace) await rm(workspace, { recursive: true, force: true, maxRetries: 5 });
 
     // If the defect regresses, these land in the package tree — the very thing the test asserts
     // against — and a red run would leave them behind as untracked files in the repo. Clean them

--- a/server/tests/e2e/shell-verify-e2e.test.ts
+++ b/server/tests/e2e/shell-verify-e2e.test.ts
@@ -40,7 +40,7 @@ describe('Shell Verify E2E', () => {
 
   afterEach(async () => {
     try {
-      await rm(tempDir, { recursive: true, force: true });
+      await rm(tempDir, { recursive: true, force: true, maxRetries: 5 });
     } catch {
       // Ignore cleanup errors
     }


### PR DESCRIPTION
## Summary

After this merges, the `resource-write-destination` e2e suite no longer fails its own teardown while every test in it passes — the server is awaited to exit before its workspace is removed.

- `stop()` was `proc?.kill()`, fire-and-forget; `afterAll` raced the dying server's log flush.
- The fix is the exact pattern `resource-path-containment.e2e.test.ts` already ships for the identical race; two sibling `rm` sites missing the `maxRetries: 5` belt get it too.

## Demonstration

**Before** — first CI run of both #257 and #259:

```
FAIL tests/e2e/resource-write-destination.e2e.test.ts
  ● Test suite failed to run
    ENOTEMPTY: directory not empty, rmdir '/tmp/write-dest-e2e-5ophUD/logs'
Test Suites: 1 failed, 7 passed  ·  Tests: 184 passed
```

**After** — exit is awaited, then the tree is removed:

```
Test Suites: 1 passed, 1 total
Tests:       3 passed, 3 total
```

## How it was verified

| Claim | Probe | Baseline → measured | Mutation that fails it |
| --- | --- | --- | --- |
| The suite passes with the awaited stop | `npx jest tests/e2e/resource-write-destination` against a fresh `dist/` | 4 local runs green | a race: not deterministically reproducible locally — the mechanism argument and the sibling's track record carry the claim |
| The pattern is the proven one | `rg "once\('exit'" tests/e2e/` | `resource-path-containment` and `resource-copy-on-write` ship it and have never hit ENOTEMPTY | — |
| No new leak | same run, sibling suite as control | both suites report identical clean epilogues | — |

## Notes for Reviewers

- The 5-second `setTimeout(resolve, …)` fallback in `stop()` is copied verbatim from the sibling rather than improved — matching a green pattern beats optimizing an unproven one.

## Still open

None

## README Charter Compliance

Not applicable
