### PR TITLE
fix(ci): a plan footer asserts progress, not same-PR retirement

### DIFF
--- a/.github/workflows/pr-conventions.yml
+++ b/.github/workflows/pr-conventions.yml
@@ -126,6 +126,13 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # The plan-footer check measures which rows this PR closes by comparing the plan against
+          # its state at the merge base, so it needs history the default `fetch-depth: 1` does not
+          # fetch. The check fails loudly when the base is unreadable rather than passing, so a
+          # regression here surfaces as a red gate on every PR carrying a footer, not as a silent
+          # green — but it would be a wrong red, so keep this.
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0

--- a/.github/workflows/pr-conventions.yml
+++ b/.github/workflows/pr-conventions.yml
@@ -143,6 +143,15 @@ jobs:
         if: github.event.pull_request.user.type != 'Bot'
         run: node scripts/validate-pr-body.mjs --self-test
 
+      # The self-test above drives the plan rules off fixtures, so it proves the RULES and says
+      # nothing about whether this checkout can supply them a base to compare against. That gap is
+      # where the `fetch-depth` regression lives: a shallow checkout does not error, it compares the
+      # plan against itself and reports "closes no rows" for every PR. Asserted on every PR, not
+      # only ones carrying a footer, because the configuration is repository-wide.
+      - name: Prove the checkout can measure plan progress (positive control)
+        if: github.event.pull_request.user.type != 'Bot'
+        run: node scripts/validate-pr-body.mjs --assert-base-measurable
+
       - name: Check the body against the template (scripts/validate-pr-body.mjs)
         if: github.event.pull_request.user.type != 'Bot'
         env:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -333,8 +333,27 @@ them one-concern and short (commitlint warns past 1,500 characters).
 
 **Plan footer contract.** A PR executing a plan ends its body with exactly one line --
 `` Plan: `plans/<path>.md` `` -- and mentions the plan nowhere else (no row ids, no plan
-vocabulary). The gate fails while that plan's `status:` is non-final: finalize the plan (every
-row terminal, retired) in the same PR, or the PR does not merge.
+vocabulary). The footer is an assertion -- _this PR advances that plan_ -- and the gate checks it
+in two halves, both derived from the diff rather than taken on the author's word:
+
+| Half         | What it requires                                                                                             | When it fires                  |
+| ------------ | ------------------------------------------------------------------------------------------------------------ | ------------------------------ |
+| **Progress** | at least one row moves from `☐` to a terminal mark (`✓`, `✗`, `⊘`) between the merge base and this PR's head | every PR carrying a footer     |
+| **Closure**  | the plan carries a final `status:`                                                                           | once no row is left unfinished |
+
+So a multi-phase plan merges in as many PRs as it takes, and the PR that closes its last row is the
+one that must retire it. There is deliberately no opt-out marker: a footer flag saying "partial"
+would be author-set and unfalsifiable, which retires the gate rather than satisfying it.
+
+A row nobody has marked counts as **unfinished**, not as done -- so an unmarked row keeps a plan
+open rather than triggering a demand to retire it. Where a plan's tables are graded by words
+(`RULED`, `REVISED`) instead of the `☐`/`✓`/`✗`/`⊘` vocabulary, there is no progress to measure and
+the original rule stands unchanged: finalize the plan in the same PR, or the PR does not merge.
+
+_Until 2026-09-06 the single rule was "finalize the plan in this PR". It was reachable only by
+plans short enough to finish in one PR: #262 named a six-phase umbrella whose open rows spanned an
+unbuilt resource type and a four-repository rename arc, so the gate was red with no green available
+to it -- a gate that cannot be retired, which `cleanup-standards.md` prices as a bug._
 
 **The squash-merge commit carries the PR title and body, verbatim.** That is a repository setting
 (`squash_merge_commit_title: PR_TITLE`, `squash_merge_commit_message: PR_BODY`, set 2026-09-01;

--- a/scripts/validate-pr-body.mjs
+++ b/scripts/validate-pr-body.mjs
@@ -49,10 +49,13 @@
  *   node scripts/validate-pr-body.mjs --self-test
  */
 
+import { execFileSync } from 'node:child_process';
 import { existsSync, mkdtempSync, readFileSync, mkdirSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+
+import { planRowStates } from '../server/scripts/validate-plan-row-tracking.js';
 
 export const REQUIRED_SECTIONS = ['Summary', 'How it was verified', 'Notes for Reviewers'];
 export const DEMONSTRATION_SECTION = 'Demonstration';
@@ -155,21 +158,135 @@ function checkVerificationRows(sections, failures) {
   }
 }
 
-function checkPlanFooter(body, failures, repoRoot) {
+/**
+ * The plan as it stood at the merge base, or `null` when that cannot be read.
+ *
+ * Merge base rather than the base branch tip: rows closed on `main` after this branch forked are
+ * not this PR's progress, and counting them would let a stale branch pass on someone else's work.
+ *
+ * `null` is NOT "no change" — it is "cannot measure", and the caller fails on it. A shallow
+ * checkout (`actions/checkout` defaults to `fetch-depth: 1`) reaches this path, and a gate that
+ * read an unreadable base as a silent pass would report green for exactly the configuration that
+ * blinded it.
+ */
+function planAtMergeBase(repoRoot, relPath) {
+  const baseRef = process.env.GITHUB_BASE_REF
+    ? `origin/${process.env.GITHUB_BASE_REF}`
+    : 'origin/HEAD';
+  const git = (args) =>
+    execFileSync('git', args, {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+  try {
+    return git(['show', `${git(['merge-base', baseRef, 'HEAD']).trim()}:${relPath}`]);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * A `Plan:` footer asserts that this PR advances the plan it names. This checks that assertion.
+ *
+ * WHY IT IS NO LONGER "the plan must be finalized in this PR". That was the original rule, and it
+ * is satisfiable only by a plan short enough to finish in one PR. Measured 2026-09-06 on #262: the
+ * plan it names is a six-phase umbrella whose open rows span a whole unbuilt resource type and a
+ * four-repository rename arc, so no PR in this repo could ever retire it — the gate was red with
+ * no reachable green, which `cleanup-standards.md` prices as a bug rather than a standard. The
+ * defect the plan `status:` field exists for is narrower, and that plan's own preamble states it:
+ * "`status:`, so "is it done" had no answer — Arc 1 was complete while 29 rows were open."
+ *
+ * So the guarantee splits into the two halves that are separately checkable, and BOTH are derived
+ * from the diff rather than asserted by the author. There is deliberately no opt-out flag: a
+ * footer marker that suppressed this check would be author-set and unfalsifiable, which retires
+ * the gate instead of satisfying it.
+ *
+ *   PROGRESS — the PR must move at least one row from ☐ to a terminal mark. A footer on a PR that
+ *   closes nothing is either pointed at the wrong plan or decorating.
+ *
+ *   CLOSURE — when no row is left unfinished, the plan must carry a final `status:`. This is the
+ *   original guarantee, enforced at the one moment it is both meaningful and reachable: the last
+ *   PR of a plan still cannot leave it open.
+ *
+ * WHERE IT DECLINES TO MEASURE, and why that falls back to the OLD rule rather than to a pass:
+ * plans are graded through the ☐/✓/✗/⊘ vocabulary, and some tables use words instead (`RULED`,
+ * `REVISED`) or carry no status column at all. When the plan has no ☐ row at the merge base there
+ * is no progress to measure, so the original strict rule applies unchanged. The relaxation reaches
+ * exactly the plans this vocabulary can grade, and nothing else.
+ */
+function checkPlanFooter(body, failures, repoRoot, readPlanAtMergeBase) {
   const match = /^Plan:\s*`?(plans\/\S+?)`?\s*$/m.exec(stripComments(body));
   if (!match) return;
-  const planPath = path.join(repoRoot, match[1]);
+  const relPath = match[1];
+  const planPath = path.join(repoRoot, relPath);
   if (!existsSync(planPath)) {
-    failures.push(`\`Plan:\` footer names \`${match[1]}\`, which does not exist at this checkout`);
+    failures.push(`\`Plan:\` footer names \`${relPath}\`, which does not exist at this checkout`);
     return;
   }
-  const status = /^status:\s*(\S+)/m.exec(readFileSync(planPath, 'utf8'))?.[1]?.toLowerCase();
+
+  const head = readFileSync(planPath, 'utf8');
+  const status = /^status:\s*(\S+)/m.exec(head)?.[1]?.toLowerCase();
   if (status === undefined) {
-    failures.push(`\`Plan:\` footer names \`${match[1]}\`, which declares no \`status:\``);
-  } else if (NON_FINAL_STATUSES.has(status)) {
+    failures.push(`\`Plan:\` footer names \`${relPath}\`, which declares no \`status:\``);
+    return;
+  }
+
+  const mustFinalize = () =>
     failures.push(
-      `\`Plan:\` footer names \`${match[1]}\` with status \`${status}\` — a PR carrying a plan ` +
+      `\`Plan:\` footer names \`${relPath}\` with status \`${status}\` — a PR carrying a plan ` +
         'merges only once that plan is finalized (retired with every row terminal) in this same PR'
+    );
+
+  const rows = planRowStates(head);
+  const unfinished = rows.filter((row) => row.state !== 'terminal');
+
+  // No gradable row at all: nothing to measure, so the original rule stands.
+  if (rows.length === 0) {
+    if (NON_FINAL_STATUSES.has(status)) mustFinalize();
+    return;
+  }
+
+  // CLOSURE. `unmarked` counts as unfinished on purpose — a row nobody has spoken for cannot
+  // certify that a plan is complete, and reading it as terminal would demand the retirement of a
+  // plan with live work in it.
+  if (unfinished.length === 0) {
+    if (NON_FINAL_STATUSES.has(status)) {
+      failures.push(
+        `\`Plan:\` footer names \`${relPath}\`, whose ${rows.length} rows are all terminal while ` +
+          `\`status:\` is still \`${status}\` — the PR that closes a plan's last row retires the ` +
+          'plan. Set a final `status:` in this PR.'
+      );
+    }
+    return;
+  }
+
+  // A plan already carrying a final status has nothing left to prove here.
+  if (!NON_FINAL_STATUSES.has(status)) return;
+
+  const base = readPlanAtMergeBase(relPath);
+  if (base === null) {
+    failures.push(
+      `\`Plan:\` footer names \`${relPath}\`, but the plan as it stood at the merge base could ` +
+        'not be read, so the rows this PR closes cannot be measured. The checkout needs full ' +
+        'history (`fetch-depth: 0`) and a fetched base ref.'
+    );
+    return;
+  }
+
+  const baseState = new Map(planRowStates(base).map((row) => [row.id, row.state]));
+  if (![...baseState.values()].includes('open')) {
+    mustFinalize();
+    return;
+  }
+
+  // PROGRESS.
+  const closed = rows.filter((row) => row.state === 'terminal' && baseState.get(row.id) === 'open');
+  if (closed.length === 0) {
+    failures.push(
+      `\`Plan:\` footer names \`${relPath}\` with status \`${status}\` and ${unfinished.length} ` +
+        'unfinished row(s), and this PR closes none of them. A plan footer asserts that this PR ' +
+        'advances that plan — mark the rows it finishes terminal (✓, ✗ or ⊘), or drop the footer.'
     );
   }
 }
@@ -198,13 +315,17 @@ function collectWarnings(body, sections) {
  */
 export function checkBody(body, title, options = {}) {
   const repoRoot = options.repoRoot ?? REPO_ROOT;
+  // Injected so the self-test drives the plan rules off fixtures rather than a real git history,
+  // which keeps every rule in this file pure and replayable.
+  const readPlanAtMergeBase =
+    options.readPlanAtMergeBase ?? ((relPath) => planAtMergeBase(repoRoot, relPath));
   const sections = splitSections(body);
   const failures = [];
   checkRequiredSections(sections, failures);
   checkDemonstration(sections, title, failures);
   checkPlaceholders(body, failures);
   checkVerificationRows(sections, failures);
-  checkPlanFooter(body, failures, repoRoot);
+  checkPlanFooter(body, failures, repoRoot, readPlanAtMergeBase);
   return { failures, warnings: collectWarnings(body, sections) };
 }
 
@@ -213,12 +334,79 @@ function readArg(flag) {
   return index === -1 ? undefined : process.argv[index + 1];
 }
 
+/** A minimal plan whose table carries the `St` column `planRowStates` grades. */
+function fixturePlan(status, rows) {
+  const body = rows.map(([id, mark]) => `| ${id} | ${mark} | change |`).join('\n');
+  return `---\nstatus: ${status}\n---\n\n| Id | St | Change |\n|---|---|---|\n${body}\n`;
+}
+
+const OPEN_PAIR = [
+  ['R1', '☐'],
+  ['R2', '☐'],
+];
+
+/**
+ * Plan fixtures as `{ [relPath]: [headText, baseText] }`; a `null` base models one that cannot be
+ * read.
+ *
+ * Every plan rule is exercised in BOTH directions — a case where it must fire and a case where it
+ * must stay silent — because a rule that only ever fires is indistinguishable from one that always
+ * fires.
+ */
+const PLAN_FIXTURES = {
+  // Rowless plans: the original rule, unchanged.
+  'plans/active.md': ['---\nstatus: active\n---\n', null],
+  'plans/retired.md': ['---\nstatus: reference\n---\n', null],
+  // PROGRESS, in each of the three terminal marks.
+  'plans/progress.md': [
+    fixturePlan('active', [['R1', '✓'], ['R2', '☐']]),
+    fixturePlan('active', OPEN_PAIR),
+  ],
+  'plans/killed.md': [
+    fixturePlan('active', [['R1', '✗'], ['R2', '☐']]),
+    fixturePlan('active', OPEN_PAIR),
+  ],
+  'plans/no-change-needed.md': [
+    fixturePlan('active', [['R1', '⊘'], ['R2', '☐']]),
+    fixturePlan('active', OPEN_PAIR),
+  ],
+  // PROGRESS, converse: nothing moved.
+  'plans/stalled.md': [fixturePlan('active', OPEN_PAIR), fixturePlan('active', OPEN_PAIR)],
+  // CLOSURE, both directions.
+  'plans/all-terminal-active.md': [
+    fixturePlan('active', [['R1', '✓'], ['R2', '⊘']]),
+    fixturePlan('active', OPEN_PAIR),
+  ],
+  'plans/all-terminal-retired.md': [
+    fixturePlan('reference', [['R1', '✓'], ['R2', '⊘']]),
+    fixturePlan('active', OPEN_PAIR),
+  ],
+  // An unmarked row is not terminal: closure must NOT demand retirement while one survives.
+  'plans/unmarked-row.md': [
+    fixturePlan('active', [['R1', '✓'], ['R2', 'RULED']]),
+    fixturePlan('active', [['R1', '☐'], ['R2', 'RULED']]),
+  ],
+  // Graded by words rather than glyphs: no ☐ at base, so the original rule applies.
+  'plans/word-vocabulary.md': [
+    fixturePlan('active', [['R1', 'RULED'], ['R2', 'REVISED']]),
+    fixturePlan('active', [['R1', 'RULED'], ['R2', 'REVISED']]),
+  ],
+  // A merge base that cannot be read (a shallow checkout): must fail, never silently pass.
+  'plans/unreadable-base.md': [fixturePlan('active', [['R1', '✓'], ['R2', '☐']]), null],
+};
+
 function selfTestFixtures() {
   const root = mkdtempSync(path.join(tmpdir(), 'pr-body-selftest-'));
   mkdirSync(path.join(root, 'plans'), { recursive: true });
-  writeFileSync(path.join(root, 'plans', 'active.md'), '---\nstatus: active\n---\n');
-  writeFileSync(path.join(root, 'plans', 'retired.md'), '---\nstatus: reference\n---\n');
+  for (const [relPath, [head]] of Object.entries(PLAN_FIXTURES)) {
+    writeFileSync(path.join(root, relPath), head);
+  }
   return root;
+}
+
+/** Serves the fixture base texts; `null` models a base that cannot be read. */
+function fixtureBaseReader(relPath) {
+  return PLAN_FIXTURES[relPath]?.[1] ?? null;
 }
 
 function selfTest() {
@@ -293,6 +481,60 @@ function selfTest() {
       expect: (r) => r.failures.some((f) => f.includes('does not exist')),
     },
     {
+      name: 'a PR that closes an open row passes though the plan stays active',
+      body: `${filled}\nPlan: \`plans/progress.md\`\n`,
+      title: 'feat(chains): x',
+      expect: noFail,
+    },
+    {
+      name: 'a ✗ kill closes a row',
+      body: `${filled}\nPlan: \`plans/killed.md\`\n`,
+      title: 'feat(chains): x',
+      expect: noFail,
+    },
+    {
+      name: 'a ⊘ no-change-required closes a row',
+      body: `${filled}\nPlan: \`plans/no-change-needed.md\`\n`,
+      title: 'feat(chains): x',
+      expect: noFail,
+    },
+    {
+      name: 'a footer on a plan this PR does not advance fails',
+      body: `${filled}\nPlan: \`plans/stalled.md\`\n`,
+      title: 'feat(chains): x',
+      expect: (r) => r.failures.some((f) => f.includes('closes none of them')),
+    },
+    {
+      name: 'closing the last row without retiring the plan fails',
+      body: `${filled}\nPlan: \`plans/all-terminal-active.md\`\n`,
+      title: 'feat(chains): x',
+      expect: (r) => r.failures.some((f) => f.includes('retires the')),
+    },
+    {
+      name: 'closing the last row and retiring the plan passes',
+      body: `${filled}\nPlan: \`plans/all-terminal-retired.md\`\n`,
+      title: 'feat(chains): x',
+      expect: noFail,
+    },
+    {
+      name: 'an unmarked row is unfinished, so closure does not demand retirement',
+      body: `${filled}\nPlan: \`plans/unmarked-row.md\`\n`,
+      title: 'feat(chains): x',
+      expect: (r) => noFail(r) && !r.failures.some((f) => f.includes('retires the')),
+    },
+    {
+      name: 'a plan graded by words keeps the original finalize-in-this-PR rule',
+      body: `${filled}\nPlan: \`plans/word-vocabulary.md\`\n`,
+      title: 'feat(chains): x',
+      expect: (r) => r.failures.some((f) => f.includes('finalized')),
+    },
+    {
+      name: 'an unreadable merge base fails rather than passing silently',
+      body: `${filled}\nPlan: \`plans/unreadable-base.md\`\n`,
+      title: 'feat(chains): x',
+      expect: (r) => r.failures.some((f) => f.includes('merge base')),
+    },
+    {
       name: 'prose over budget warns, transcripts and details do not count',
       body:
         filled.replace('After this merges, x.', `${'word '.repeat(WORD_BUDGET + 1)}`) +
@@ -319,7 +561,10 @@ function selfTest() {
   ];
   let failed = 0;
   for (const c of cases) {
-    const result = checkBody(c.body, c.title, { repoRoot: root });
+    const result = checkBody(c.body, c.title, {
+      repoRoot: root,
+      readPlanAtMergeBase: fixtureBaseReader,
+    });
     const ok = c.expect(result);
     console.log(`${ok ? 'PASS' : 'FAIL'}  ${c.name}`);
     if (!ok) {

--- a/scripts/validate-pr-body.mjs
+++ b/scripts/validate-pr-body.mjs
@@ -159,17 +159,20 @@ function checkVerificationRows(sections, failures) {
 }
 
 /**
- * The plan as it stood at the merge base, or `null` when that cannot be read.
+ * The commit this PR forked from, as `{ mergeBase }`, or `{ error }` when no honest comparison is
+ * available from this checkout.
  *
  * Merge base rather than the base branch tip: rows closed on `main` after this branch forked are
  * not this PR's progress, and counting them would let a stale branch pass on someone else's work.
  *
- * `null` is NOT "no change" — it is "cannot measure", and the caller fails on it. A shallow
- * checkout (`actions/checkout` defaults to `fetch-depth: 1`) reaches this path, and a gate that
- * read an unreadable base as a silent pass would report green for exactly the configuration that
- * blinded it.
+ * BOTH failure modes are vacuity, not absence, and that is the whole reason this is separate from
+ * the read below. Measured 2026-09-06 by cloning one branch twice, once with `--depth=1`: a shallow
+ * checkout does NOT make `git merge-base` fail. It resolves to HEAD, the plan is compared against
+ * ITSELF, and every PR is told it closes no rows — a wrong red wearing the message of a right one,
+ * pointing the author at their plan instead of at the checkout. `actions/checkout` defaults to
+ * `fetch-depth: 1`, so that is the configuration a regression lands in.
  */
-function planAtMergeBase(repoRoot, relPath) {
+function resolveMergeBase(repoRoot) {
   const baseRef = process.env.GITHUB_BASE_REF
     ? `origin/${process.env.GITHUB_BASE_REF}`
     : 'origin/HEAD';
@@ -180,10 +183,6 @@ function planAtMergeBase(repoRoot, relPath) {
       stdio: ['ignore', 'pipe', 'ignore'],
     });
 
-  // A shallow clone has no fork point to find. Measured 2026-09-06: `git merge-base` does not
-  // error there — it resolves to HEAD, and the plan is then compared against ITSELF. That vacuous
-  // comparison reports "this PR closes no rows" for every PR, which is a WRONG red wearing the
-  // message of a right one, and it sends the author to their plan rows instead of the checkout.
   if (git(['rev-parse', '--is-shallow-repository']).trim() === 'true') {
     return { error: 'the checkout is shallow, so there is no merge base to compare against' };
   }
@@ -195,7 +194,7 @@ function planAtMergeBase(repoRoot, relPath) {
     return { error: `\`${baseRef}\` is not present in this checkout` };
   }
 
-  // The same vacuity, reached a second way: a base ref that resolves to HEAD itself measures
+  // The same vacuity reached a second way: a base ref that resolves to HEAD itself measures
   // nothing. Checked by value rather than by name, because which ref aliases HEAD varies by how
   // the checkout was made.
   if (mergeBase === git(['rev-parse', 'HEAD']).trim()) {
@@ -204,8 +203,15 @@ function planAtMergeBase(repoRoot, relPath) {
     };
   }
 
+  return { mergeBase, git };
+}
+
+/** The plan as it stood at the merge base; `{ text: null }` when this PR introduces it. */
+function planAtMergeBase(repoRoot, relPath) {
+  const resolved = resolveMergeBase(repoRoot);
+  if (resolved.error) return { error: resolved.error };
   try {
-    return { text: git(['show', `${mergeBase}:${relPath}`]) };
+    return { text: resolved.git(['show', `${resolved.mergeBase}:${relPath}`]) };
   } catch {
     // Absent at the merge base means this PR introduces the plan — measurable, and permitted.
     return { text: null };
@@ -625,9 +631,37 @@ function selfTest() {
   return failed === 0;
 }
 
+/**
+ * Asserts this checkout can answer "which rows did this PR close" AT ALL.
+ *
+ * A positive control for the plan-footer check, and deliberately built on `resolveMergeBase` — the
+ * same call the check itself makes — so the control cannot report a measurable checkout while the
+ * gate reads an unmeasurable one. Runs on every PR rather than only on PRs carrying a footer,
+ * because the configuration it guards (`fetch-depth`) is repository-wide: a regression should
+ * surface on the next PR of any kind, not lie in wait for the next one that names a plan.
+ */
+function assertBaseMeasurable() {
+  const resolved = resolveMergeBase(REPO_ROOT);
+  const ci = process.env.GITHUB_ACTIONS === 'true';
+  if (resolved.error) {
+    const message =
+      `the plan-footer check cannot measure this checkout: ${resolved.error}. Any PR carrying ` +
+      'a `Plan:` footer would be judged against a vacuous comparison. Restore `fetch-depth: 0` ' +
+      'on the checkout step in .github/workflows/pr-conventions.yml.';
+    console.log(ci ? `::error::${message}` : `error: ${message}`);
+    return false;
+  }
+  const base = resolved.mergeBase.slice(0, 8);
+  console.log(`merge base resolves to ${base} — plan progress is measurable.`);
+  return true;
+}
+
 function main() {
   if (process.argv.includes('--self-test')) {
     process.exit(selfTest() ? 0 : 1);
+  }
+  if (process.argv.includes('--assert-base-measurable')) {
+    process.exit(assertBaseMeasurable() ? 0 : 1);
   }
   const bodyFile = readArg('--body-file');
   const body = bodyFile ? readFileSync(bodyFile, 'utf8') : (process.env.PR_BODY ?? '');

--- a/scripts/validate-pr-body.mjs
+++ b/scripts/validate-pr-body.mjs
@@ -179,10 +179,36 @@ function planAtMergeBase(repoRoot, relPath) {
       encoding: 'utf8',
       stdio: ['ignore', 'pipe', 'ignore'],
     });
+
+  // A shallow clone has no fork point to find. Measured 2026-09-06: `git merge-base` does not
+  // error there — it resolves to HEAD, and the plan is then compared against ITSELF. That vacuous
+  // comparison reports "this PR closes no rows" for every PR, which is a WRONG red wearing the
+  // message of a right one, and it sends the author to their plan rows instead of the checkout.
+  if (git(['rev-parse', '--is-shallow-repository']).trim() === 'true') {
+    return { error: 'the checkout is shallow, so there is no merge base to compare against' };
+  }
+
+  let mergeBase;
   try {
-    return git(['show', `${git(['merge-base', baseRef, 'HEAD']).trim()}:${relPath}`]);
+    mergeBase = git(['merge-base', baseRef, 'HEAD']).trim();
   } catch {
-    return null;
+    return { error: `\`${baseRef}\` is not present in this checkout` };
+  }
+
+  // The same vacuity, reached a second way: a base ref that resolves to HEAD itself measures
+  // nothing. Checked by value rather than by name, because which ref aliases HEAD varies by how
+  // the checkout was made.
+  if (mergeBase === git(['rev-parse', 'HEAD']).trim()) {
+    return {
+      error: `\`${baseRef}\` resolves to this branch's own tip, so the comparison would be vacuous`,
+    };
+  }
+
+  try {
+    return { text: git(['show', `${mergeBase}:${relPath}`]) };
+  } catch {
+    // Absent at the merge base means this PR introduces the plan — measurable, and permitted.
+    return { text: null };
   }
 }
 
@@ -265,16 +291,21 @@ function checkPlanFooter(body, failures, repoRoot, readPlanAtMergeBase) {
   if (!NON_FINAL_STATUSES.has(status)) return;
 
   const base = readPlanAtMergeBase(relPath);
-  if (base === null) {
+  if (base.error) {
     failures.push(
-      `\`Plan:\` footer names \`${relPath}\`, but the plan as it stood at the merge base could ` +
-        'not be read, so the rows this PR closes cannot be measured. The checkout needs full ' +
-        'history (`fetch-depth: 0`) and a fetched base ref.'
+      `\`Plan:\` footer names \`${relPath}\`, but the rows this PR closes cannot be measured: ` +
+        `${base.error}. The workflow checkout needs full history (\`fetch-depth: 0\`) and a ` +
+        'fetched base ref.'
     );
     return;
   }
 
-  const baseState = new Map(planRowStates(base).map((row) => [row.id, row.state]));
+  // The plan does not exist at the merge base, so this PR introduces it. Writing a plan IS
+  // advancing it, and demanding that a PR close a row of a plan it just authored would block the
+  // one PR that legitimately has no prior state to beat.
+  if (base.text === null) return;
+
+  const baseState = new Map(planRowStates(base.text).map((row) => [row.id, row.state]));
   if (![...baseState.values()].includes('open')) {
     mustFinalize();
     return;
@@ -391,8 +422,13 @@ const PLAN_FIXTURES = {
     fixturePlan('active', [['R1', 'RULED'], ['R2', 'REVISED']]),
     fixturePlan('active', [['R1', 'RULED'], ['R2', 'REVISED']]),
   ],
-  // A merge base that cannot be read (a shallow checkout): must fail, never silently pass.
-  'plans/unreadable-base.md': [fixturePlan('active', [['R1', '✓'], ['R2', '☐']]), null],
+  // A merge base that cannot be measured (a shallow checkout): must fail, never silently pass.
+  'plans/unreadable-base.md': [
+    fixturePlan('active', [['R1', '✓'], ['R2', '☐']]),
+    { error: 'the checkout is shallow, so there is no merge base to compare against' },
+  ],
+  // Absent at the merge base: this PR introduces the plan, which is itself the advance.
+  'plans/brand-new.md': [fixturePlan('active', [['R1', '☐'], ['R2', '☐']]), { text: null }],
 };
 
 function selfTestFixtures() {
@@ -404,9 +440,15 @@ function selfTestFixtures() {
   return root;
 }
 
-/** Serves the fixture base texts; `null` models a base that cannot be read. */
+/**
+ * Serves the fixture base state in the shape `planAtMergeBase` returns: `{ text }` for a readable
+ * base, `{ text: null }` for a plan this PR introduces, `{ error }` for one that cannot be
+ * measured. A bare string is sugar for `{ text }`.
+ */
 function fixtureBaseReader(relPath) {
-  return PLAN_FIXTURES[relPath]?.[1] ?? null;
+  const base = PLAN_FIXTURES[relPath]?.[1];
+  if (base === undefined || base === null) return { text: null };
+  return typeof base === 'string' ? { text: base } : base;
 }
 
 function selfTest() {
@@ -529,10 +571,18 @@ function selfTest() {
       expect: (r) => r.failures.some((f) => f.includes('finalized')),
     },
     {
-      name: 'an unreadable merge base fails rather than passing silently',
+      name: 'an unmeasurable merge base fails, naming the checkout rather than the plan',
       body: `${filled}\nPlan: \`plans/unreadable-base.md\`\n`,
       title: 'feat(chains): x',
-      expect: (r) => r.failures.some((f) => f.includes('merge base')),
+      expect: (r) =>
+        r.failures.some((f) => f.includes('shallow') && f.includes('fetch-depth')) &&
+        !r.failures.some((f) => f.includes('closes none of them')),
+    },
+    {
+      name: 'a plan this PR introduces needs no prior row to close',
+      body: `${filled}\nPlan: \`plans/brand-new.md\`\n`,
+      title: 'feat(chains): x',
+      expect: noFail,
     },
     {
       name: 'prose over budget warns, transcripts and details do not count',

--- a/server/scripts/validate-plan-row-tracking.js
+++ b/server/scripts/validate-plan-row-tracking.js
@@ -115,6 +115,19 @@ const OPEN_MARK = '☐';
 /** Closed, no change required — settled but produced no edit. Rule 3 makes it carry a stamp too. */
 const CLOSED_MARK = '⊘';
 
+/** Killed — the work was judged not worth its cost. A terminal state, like ✓ and ⊘. */
+const KILLED_MARK = '✗';
+
+/**
+ * The three MARKED states. A row carrying any of them has been spoken for; `☐` has not.
+ *
+ * Kept as one list because every consumer that asks "is this row still open" must ask about all
+ * three. Enumerating two of them is the bug it exists to prevent: `⊘` was added after `✓` and `✗`,
+ * so a check written against the older pair reads a settled row as pending and reports a plan as
+ * unfinished forever.
+ */
+const TERMINAL_MARKS = [DONE_MARK, CLOSED_MARK, KILLED_MARK];
+
 /**
  * The stamp that turns an open marker into something re-checkable.
  *
@@ -287,6 +300,63 @@ function statusColumnByLine(lines) {
 function statusTextOf(line, column) {
   if (column === undefined) return line;
   return cellsOf(line)[column] ?? '';
+}
+
+/**
+ * Every gradable plan row, as `{ id, state }`, where `state` is `open` or `terminal`.
+ *
+ * This is the row-lifecycle primitive the other consumers of plan state share, so that "what
+ * counts as a row" and "what counts as closed" have ONE answer. `scripts/validate-pr-body.mjs`
+ * reads it to decide whether a PR advances the plan its footer names; keeping that logic here
+ * rather than reimplementing it there is the difference between a second parser and a second
+ * caller — a second parser drifts, and the drift is silent because both sides still return rows.
+ *
+ * `☐` wins over a terminal mark when a row somehow carries both. A row that is ambiguous about
+ * whether it is finished is not finished, and the conservative reading is the one that cannot
+ * report a plan as further along than it is.
+ *
+ * TWO DELIBERATE EXCLUSIONS, both of which cost coverage rather than correctness:
+ *
+ * A row is skipped when its table declares no status column (`statusColumnByLine` yields
+ * `undefined`). `auditOpenRows` falls back to scanning the whole line in that case; here the
+ * fallback would be worse than the gap, because this function's answer is compared ACROSS two
+ * revisions — a whole-line scan makes any prose edit that mentions a glyph look like a lifecycle
+ * transition. A plan whose tables carry no `St` column simply yields no rows, and the caller is
+ * responsible for saying so rather than reading the empty list as "nothing left to do".
+ *
+ * A row is skipped when its first cell is empty, because the id is what lets the same row be
+ * recognised on both sides of a diff. Rows are matched by id and never by position: a plan grows
+ * rows between two revisions, so line numbers name different rows in each.
+ *
+ * @param {string} content
+ * @returns {{ id: string, state: 'open' | 'terminal', line: number }[]}
+ */
+export function planRowStates(content) {
+  const lines = content.split('\n');
+  const statusColumn = statusColumnByLine(lines);
+  const rows = [];
+
+  for (const [index, line] of lines.entries()) {
+    if (!line.trim().startsWith('|')) continue;
+    if (isSeparatorRow(line)) continue;
+
+    const column = statusColumn[index];
+    if (column === undefined) continue;
+
+    const id = (cellsOf(line)[0] ?? '').replace(/[*`]/g, '').trim();
+    if (!id) continue;
+
+    const status = statusTextOf(line, column);
+    const state = status.includes(OPEN_MARK)
+      ? 'open'
+      : TERMINAL_MARKS.some((mark) => status.includes(mark))
+        ? 'terminal'
+        : 'unmarked';
+
+    rows.push({ id, state, line: index + 1 });
+  }
+
+  return rows;
 }
 
 /**
@@ -797,4 +867,10 @@ function selfTest() {
   return failures === 0 ? 0 : 1;
 }
 
-process.exit(process.argv.includes('--self-test') ? selfTest() : run());
+// Run only when invoked as a command. This file exports its audits so other gates can reuse the
+// row vocabulary, and an unguarded `process.exit` made those exports unreachable: importing them
+// ran the whole plan audit and terminated the importing process. Same idiom as
+// `run-validation-suite.js`.
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  process.exit(process.argv.includes('--self-test') ? selfTest() : run());
+}


### PR DESCRIPTION
## Summary

After this merges, a PR executing one phase of a long-running plan can merge without retiring the whole plan — while the plan still cannot be abandoned half-finished.

- A `Plan:` footer now asserts **progress**: the PR must close at least one plan row, measured against the plan at the merge base.
- The PR closing a plan's **last** row must retire it — the previous rule, enforced where it is reachable.
- Both facts are read from the diff. There is no marker an author can add to opt out.
- An unmarked row counts as unfinished, so it keeps a plan open rather than triggering a demand to retire it.
- Plans graded by words (`RULED`, `REVISED`) rather than status marks keep the previous rule unchanged.
- A checkout that cannot measure progress now says so by name, and every PR asserts its own is measurable.

## Demonstration

The same unmodified PR body, checked against the same branch, before and after:

```console
$ node scripts/validate-pr-body.mjs   # before — on main
error: `Plan:` footer names `plans/technical-debt/resource-surface-consolidation-2026-08-27.md`
       with status `active` — a PR carrying a plan merges only once that plan is finalized
       (retired with every row terminal) in this same PR
exit=1

$ node scripts/validate-pr-body.mjs   # after — this branch
PR body: 3 required sections present, no warnings.
exit=0
```

That plan is a six-phase umbrella whose open rows include an unbuilt resource type and a rename spanning four repositories. No single PR here could retire it, so the check was red with no green available to it.

## How it was verified

| Claim | Probe | Baseline → measured | Mutation that fails it |
| --- | --- | --- | --- |
| A PR that closes a row passes though its plan stays open | `validate-pr-body.mjs --self-test` | red before the change → 24/24 pass | serve a head where no row moved → `closes none of them` |
| A PR that closes nothing still fails | same self-test, `stalled` fixture | fails as intended | move one row to `✓` → passes |
| Closing the last row without retiring still fails | same self-test, `all-terminal-active` | fails as intended | set `status: reference` → passes |
| All three terminal marks close a row | separate `✓`, `✗`, `⊘` fixtures | 3/3 pass | drop `⊘` from the mark list → its case fails |
| An unmarked row does not read as done | `unmarked-row` fixture | no retirement demanded | treat unmarked as terminal → wrongly demands retirement |
| An unmeasurable base fails naming the checkout, not the plan | `unreadable-base` fixture | fails, and not with the row-progress message | drop the distinction → the author is sent to their plan |
| The real check agrees with the fixtures | run `checkBody` against a live PR body and real git history | 1 failure → 0 | point it at a branch closing no row → 1 failure, correct message |
| A shallow checkout is refused rather than compared against itself | clone this branch twice, once `--depth=1`, run the gate in each | both clones reported the same row error → each now names its own cause | remove the shallow guard → both agree again, wrongly |
| A PR introducing a plan needs no prior row to close | `brand-new` fixture (plan absent at base) | passes | treat absent-at-base as unreadable → wrongly fails |
| The checkout is measurable on every PR | `validate-pr-body.mjs --assert-base-measurable`, wired into the workflow | full checkout exits 0 naming the base; `--depth=1` exits 1 | — |
| The gate reads a real plan at a real merge base in CI | throwaway PR #264 against this branch, two pushes | closes no row → **failure**; closes one row → **success** | — |
| Nothing else regressed | `validate:all`, `lint:ratchet`, `validate:format`, pre-push | 53/53, no ratchet regression, format clean | — |

## Notes for Reviewers

- **Distrust `planRowStates` in `server/scripts/validate-plan-row-tracking.js`.** The only new parsing, and it defines "closed" for every caller. It grades rows only in tables declaring a status column, and reads an unrecognised status as unfinished — deliberate; confirm that is the direction you want.
- **`scripts/validate-pr-body.mjs` now imports across the root/`server` boundary.** It had zero imports so the workflow could run it before any install. The import reaches only Node builtins, so that holds — but it is the assumption most likely to break later.
- **The workflow change is load-bearing, and its first version was wrong.** A shallow checkout does not make `git merge-base` fail: it resolves to `HEAD`, the plan is compared against itself, and every PR is told it closes no rows. Two commits here exist for that reason.

## Still open

- The stale body and title on the PR this unblocks are a separate change.

<details><summary>Two pre-existing gaps found while building this, neither touched here</summary>

- **Status vocabulary drift.** Local `NON_FINAL_STATUSES` lists six statuses; `repository-standards` publishes four (`active`, `backlog`, `done`, `reference`). `proposal`, `draft`, `loaded` and `reserved` are outside the fleet vocabulary, and the upstream `retire-done-plans` binary would reject a plan carrying one.
- **Root `scripts/*.mjs` has no formatting gate.** `lint-staged` is server-scoped and the root hook checks only JSON/MD/YAML, so nothing covers those four files. Prettier resolves the root config for them, which disagrees with how two of the four are authored — running `--write` over one rewrites the entire file. Deciding which config owns them is a separate change.

</details>

## README Charter Compliance

Not applicable.
