### PR TITLE
ci(scripts): the domain ownership matrix is a checked contract, not prose

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,6 +144,7 @@ Read the relevant doc before editing. Update docs when behavior changes.
 | `npm run validate:all`            | Full validation suite                                                                                                                                                            |
 | `npm run validate:arch`           | Dependency Cruiser architecture rules                                                                                                                                            |
 | `npm run validate:contracts`      | Verify generated artifacts in sync                                                                                                                                               |
+| `npm run validate:domain-ownership` | Check the Domain Ownership Matrix against every module's `owns` declaration, both directions                                                                                    |
 | `npm run test:integration`        | FIRST for new features                                                                                                                                                           |
 | `npm run test:coverage`           | Baseline coverage (target: >80%)                                                                                                                                                 |
 | `npm run skills:export`           | Export skills from `skills-sync.yaml`                                                                                                                                            |
@@ -151,6 +152,8 @@ Read the relevant doc before editing. Update docs when behavior changes.
 ## Domain Ownership Matrix (ENFORCED)
 
 **Stages are thin orchestration. Domain logic lives in owner services.**
+
+`validate:domain-ownership` checks this table both ways against each module's `module.yaml` `owns` block -- a row and its declaration must change together, and a row naming a symbol nobody exports, or a path the symbol is not defined in, fails.
 
 | If you need...          | Owner Service                                                        | Stage May Only                                                                                                                                |
 | ----------------------- | -------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -161,13 +164,13 @@ Read the relevant doc before editing. Update docs when behavior changes.
 | Gate verdict processing | GateVerdictProcessor (`gates/services/`)                             | Call `processor.handleGateAction()`                                                                                                           |
 | Inline gate parsing     | InlineGateProcessor (`gates/services/`)                              | Call `processor.processInlineGates()`                                                                                                         |
 | Prompt resolution       | PromptRegistry (`prompts/registry.ts`)                               | Call `registry.get()`                                                                                                                         |
-| Command parsing         | CommandParser (`execution/parsers/`)                                 | Call `parser.parseCommand()`                                                                                                                  |
+| Command parsing         | UnifiedCommandParser (`execution/parsers/command-parser.ts`)         | Call `parser.parseCommand()`                                                                                                                  |
 | Step capture            | StepCaptureService (`execution/capture/`)                            | Call `captureService.captureStep()`                                                                                                           |
 | Response assembly       | ResponseAssembler (`execution/formatting/`)                          | Call `assembler.format*()`                                                                                                                    |
 | Framework selection     | FrameworkManager (`frameworks/`)                                     | Call `frameworkManager.selectFramework()`                                                                                                     |
 | Framework validity      | FrameworkManager                                                     | Call `frameworkManager.getFramework(id)` -- never hardcode                                                                                    |
 | Injection decisions     | InjectionDecisionService (`execution/pipeline/decisions/injection/`) | Call `service.decide()`                                                                                                                       |
-| Style resolution        | StyleManager (`styles/style-manager.ts`)                             | Call `styleManager.getStyle()`                                                                                                                |
+| Style resolution        | StyleManager (`modules/formatting/style-manager.ts`)                 | Call `styleManager.getStyle()`                                                                                                                |
 
 ## Key Constraints
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,6 +147,7 @@ Read the relevant doc before editing. Update docs when behavior changes.
 | `npm run validate:all`            | Full validation suite                                                                                                                                                            |
 | `npm run validate:arch`           | Dependency Cruiser architecture rules                                                                                                                                            |
 | `npm run validate:contracts`      | Verify generated artifacts in sync                                                                                                                                               |
+| `npm run validate:domain-ownership` | Check the Domain Ownership Matrix against every module's `owns` declaration, both directions                                                                                    |
 | `npm run test:integration`        | FIRST for new features                                                                                                                                                           |
 | `npm run test:coverage`           | Baseline coverage (target: >80%)                                                                                                                                                 |
 | `npm run skills:export`           | Export skills from `skills-sync.yaml`                                                                                                                                            |
@@ -154,6 +155,8 @@ Read the relevant doc before editing. Update docs when behavior changes.
 ## Domain Ownership Matrix (ENFORCED)
 
 **Stages are thin orchestration. Domain logic lives in owner services.**
+
+`validate:domain-ownership` checks this table both ways against each module's `module.yaml` `owns` block -- a row and its declaration must change together, and a row naming a symbol nobody exports, or a path the symbol is not defined in, fails.
 
 | If you need...          | Owner Service                                                        | Stage May Only                                                                                                                                |
 | ----------------------- | -------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -164,13 +167,13 @@ Read the relevant doc before editing. Update docs when behavior changes.
 | Gate verdict processing | GateVerdictProcessor (`gates/services/`)                             | Call `processor.handleGateAction()`                                                                                                           |
 | Inline gate parsing     | InlineGateProcessor (`gates/services/`)                              | Call `processor.processInlineGates()`                                                                                                         |
 | Prompt resolution       | PromptRegistry (`prompts/registry.ts`)                               | Call `registry.get()`                                                                                                                         |
-| Command parsing         | CommandParser (`execution/parsers/`)                                 | Call `parser.parseCommand()`                                                                                                                  |
+| Command parsing         | UnifiedCommandParser (`execution/parsers/command-parser.ts`)         | Call `parser.parseCommand()`                                                                                                                  |
 | Step capture            | StepCaptureService (`execution/capture/`)                            | Call `captureService.captureStep()`                                                                                                           |
 | Response assembly       | ResponseAssembler (`execution/formatting/`)                          | Call `assembler.format*()`                                                                                                                    |
 | Framework selection     | FrameworkManager (`frameworks/`)                                     | Call `frameworkManager.selectFramework()`                                                                                                     |
 | Framework validity      | FrameworkManager                                                     | Call `frameworkManager.getFramework(id)` -- never hardcode                                                                                    |
 | Injection decisions     | InjectionDecisionService (`execution/pipeline/decisions/injection/`) | Call `service.decide()`                                                                                                                       |
-| Style resolution        | StyleManager (`styles/style-manager.ts`)                             | Call `styleManager.getStyle()`                                                                                                                |
+| Style resolution        | StyleManager (`modules/formatting/style-manager.ts`)                 | Call `styleManager.getStyle()`                                                                                                                |
 
 ## MCP Tool Layer Structure
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -157,7 +157,10 @@ Descriptors explain what a boundary is. Import permission remains in
 `server/.dependency-cruiser.cjs`, which validates the dependency graph. The generated
 [Semantic Module Catalog](../reference/module-catalog.md) combines both views: authored boundary
 meaning and observed imports. Use that catalog for the current boundary inventory instead of adding
-a source tree here.
+a source tree here. Its **Domain ownership** section is generated from the `owns:` declarations in
+those same descriptors, and `validate:domain-ownership` checks them against the Domain Ownership
+Matrix in the root `CLAUDE.md` in both directions, so neither the matrix nor a declaration can drift
+alone.
 
 | Boundary                | Responsibility                                                                 |
 | ----------------------- | ------------------------------------------------------------------------------ |

--- a/docs/reference/module-catalog.md
+++ b/docs/reference/module-catalog.md
@@ -47,6 +47,29 @@ remains in `server/.dependency-cruiser.cjs`.
 | `shared-types` | `src/shared/types` | shared | canonical | Cross-layer TypeScript contracts and data shapes. | — | `index.ts` | workflow-ir | automation<br>chains<br>engine-execution<br>engine-frameworks<br>engine-gates<br>formatting<br>hot-reload<br>infra-config<br>infra-database<br>infra-hooks<br>infra-http<br>infra-logging<br>infra-observability<br>mcp-http<br>mcp-metadata<br>mcp-tools<br>prompts<br>resources<br>runtime<br>semantic<br>shared-core<br>shared-utils<br>skills-sync<br>text-references<br>versioning<br>workflow-ir |
 | `shared-utils` | `src/shared/utils` | shared | canonical | Pure cross-layer utility functions. | — | `index.ts` | shared-types | automation<br>chains<br>cli-shared<br>engine-execution<br>engine-frameworks<br>engine-gates<br>formatting<br>infra-config<br>infra-database<br>infra-observability<br>mcp-http<br>mcp-metadata<br>mcp-tools<br>prompts<br>resources<br>runtime<br>shared-core<br>skills-sync<br>text-references<br>versioning |
 
+## Domain ownership
+
+Generated from each module's `module.yaml` `owns:` block. `validate:domain-ownership` checks
+these rows against the Domain Ownership Matrix in the root `CLAUDE.md` in both directions, so a
+capability listed here and a row there cannot diverge. "Defined in" is relative to `server/src`.
+
+| Capability | Owner | Module | Defined in |
+| --- | --- | --- | --- |
+| Command parsing | `UnifiedCommandParser` | `engine-execution` | `engine/execution/parsers/command-parser.ts` |
+| Gate enforcement mode | `resolveEnforcementMode` | `engine-execution` | `engine/execution/pipeline/decisions/gates/enforcement-mode.ts` |
+| Injection decisions | `InjectionDecisionService` | `engine-execution` | `engine/execution/pipeline/decisions/injection/injection-decision-service.ts` |
+| Response assembly | `ResponseAssembler` | `engine-execution` | `engine/execution/formatting/response-assembler.ts` |
+| Step capture | `StepCaptureService` | `engine-execution` | `engine/execution/capture/step-capture-service.ts` |
+| Framework selection | `FrameworkManager` | `engine-frameworks` | `engine/frameworks/framework-manager.ts` |
+| Framework validity | `FrameworkManager` | `engine-frameworks` | `engine/frameworks/framework-manager.ts` |
+| Gate enhancement | `GateEnhancementService` | `engine-gates` | `engine/gates/services/gate-enhancement-service.ts` |
+| Gate normalization | `GateService` | `engine-gates` | `engine/gates/services/gate-service-interface.ts` |
+| Gate selection | `GateManager` | `engine-gates` | `engine/gates/gate-manager.ts` |
+| Gate verdict processing | `GateVerdictProcessor` | `engine-gates` | `engine/gates/services/gate-verdict-processor.ts` |
+| Inline gate parsing | `InlineGateProcessor` | `engine-gates` | `engine/gates/services/inline-gate-processor.ts` |
+| Style resolution | `StyleManager` | `formatting` | `modules/formatting/style-manager.ts` |
+| Prompt resolution | `PromptRegistry` | `prompts` | `modules/prompts/registry.ts` |
+
 ## Observed boundary graph
 
 Solid arrows include at least one value import. Dotted arrows contain only type imports.

--- a/server/package.json
+++ b/server/package.json
@@ -91,6 +91,8 @@
     "validate:arch:self-test": "tsx scripts/validate-arch.ts --self-test",
     "validate:module-descriptors": "tsx scripts/validate-semantic-module-descriptors.ts",
     "validate:module-descriptors:self-test": "tsx scripts/validate-semantic-module-descriptors.ts --self-test",
+    "validate:domain-ownership": "tsx scripts/validate-domain-ownership.ts",
+    "validate:domain-ownership:self-test": "tsx scripts/validate-domain-ownership.ts --self-test",
     "generate:module-catalog": "tsx scripts/generate-module-catalog.ts",
     "validate:module-catalog": "tsx scripts/generate-module-catalog.ts --check",
     "validate:module-catalog:self-test": "tsx scripts/generate-module-catalog.ts --self-test",

--- a/server/scripts/generate-module-catalog.ts
+++ b/server/scripts/generate-module-catalog.ts
@@ -10,6 +10,7 @@ import {
   runDependencyCruiser,
   type DependencyCruiserGraph,
 } from './lib/dependency-cruiser-graph.js';
+import { collectOwnershipRecords, resolveOwnershipDefinitions } from './lib/domain-ownership.js';
 import {
   loadSemanticModuleTree,
   nearestSemanticDescriptor,
@@ -27,9 +28,19 @@ export interface BoundaryEdge {
   readonly typeOnly: boolean;
 }
 
+/** One `owns` declaration, resolved to the file that actually exports the symbol. */
+export interface OwnershipCatalogRow {
+  readonly capability: string;
+  readonly symbol: string;
+  readonly moduleId: string;
+  /** Definition path relative to `server/src`, or `—` when no single file exports the symbol. */
+  readonly definedIn: string;
+}
+
 export interface ModuleCatalogModel {
   readonly descriptors: readonly SemanticModuleDescriptor[];
   readonly edges: readonly BoundaryEdge[];
+  readonly ownership: readonly OwnershipCatalogRow[];
 }
 
 function sourceModulePath(modulePath: string): boolean {
@@ -65,6 +76,38 @@ export function aggregateBoundaryEdges(
   );
 }
 
+/**
+ * The declarations `validate:domain-ownership` checks, resolved to where each symbol lives.
+ *
+ * Sorted by module then capability so the section is stable regardless of descriptor order.
+ */
+export function collectOwnershipRows(
+  descriptors: readonly SemanticModuleDescriptor[],
+  repoRoot: string,
+  sourceRoot: string
+): OwnershipCatalogRow[] {
+  const records = collectOwnershipRecords(descriptors, repoRoot);
+  const definitions = resolveOwnershipDefinitions(
+    sourceRoot,
+    records.map((record) => record.symbol)
+  );
+  return records
+    .map((record) => {
+      const paths = definitions.get(record.symbol) ?? [];
+      return {
+        capability: record.capability,
+        symbol: record.symbol,
+        moduleId: record.moduleId,
+        definedIn: paths.length === 1 ? (paths[0] as string) : '—',
+      };
+    })
+    .sort(
+      (left, right) =>
+        left.moduleId.localeCompare(right.moduleId) ||
+        left.capability.localeCompare(right.capability)
+    );
+}
+
 function escapeTableCell(value: string): string {
   return value.replaceAll('|', '\\|').replaceAll('\n', ' ');
 }
@@ -93,6 +136,11 @@ export function renderModuleCatalog(model: ModuleCatalogModel): string {
     );
   });
 
+  const ownershipRows = model.ownership.map(
+    (row) =>
+      `| ${escapeTableCell(row.capability)} | \`${row.symbol}\` | \`${row.moduleId}\` | \`${row.definedIn}\` |`
+  );
+
   const nodes = model.descriptors.map(
     (descriptor) => `  ${mermaidId(descriptor.id)}["${descriptor.id}"]`
   );
@@ -115,6 +163,16 @@ remains in \`server/.dependency-cruiser.cjs\`.
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 ${rows.join('\n')}
 
+## Domain ownership
+
+Generated from each module's \`module.yaml\` \`owns:\` block. \`validate:domain-ownership\` checks
+these rows against the Domain Ownership Matrix in the root \`CLAUDE.md\` in both directions, so a
+capability listed here and a row there cannot diverge. "Defined in" is relative to \`server/src\`.
+
+| Capability | Owner | Module | Defined in |
+| --- | --- | --- | --- |
+${ownershipRows.join('\n')}
+
 ## Observed boundary graph
 
 Solid arrows include at least one value import. Dotted arrows contain only type imports.
@@ -135,6 +193,7 @@ export function buildModuleCatalog(): ModuleCatalogModel {
   return {
     descriptors: tree.descriptors,
     edges: aggregateBoundaryEdges(graph, tree.descriptors, SERVER_ROOT),
+    ownership: collectOwnershipRows(tree.descriptors, REPO_ROOT, SOURCE_ROOT),
   };
 }
 
@@ -178,6 +237,7 @@ function selfTest(): void {
       lifecycle: 'canonical',
       description: 'Alpha.',
       children: 'internal',
+      owns: [{ capability: 'Alpha capability', symbol: 'AlphaService' }],
       absoluteDirectory: path.join(root, 'src', 'alpha'),
       descriptorPath: path.join(root, 'src', 'alpha', 'module.yaml'),
       sourcePath: 'alpha',
@@ -216,11 +276,24 @@ function selfTest(): void {
   };
   const edges = aggregateBoundaryEdges(graph, descriptors, root);
   assert.deepEqual(edges, [{ from: 'alpha', to: 'beta', typeOnly: false }]);
-  const rendered = renderModuleCatalog({ descriptors, edges });
+  const ownership: OwnershipCatalogRow[] = [
+    {
+      capability: 'Alpha capability',
+      symbol: 'AlphaService',
+      moduleId: 'alpha',
+      definedIn: 'alpha/alpha-service.ts',
+    },
+  ];
+  const rendered = renderModuleCatalog({ descriptors, edges, ownership });
   assert.match(rendered, /alpha --> module_beta/u);
   assert.doesNotMatch(rendered, /node:path/u);
-  assert.equal(rendered, renderModuleCatalog({ descriptors, edges }));
-  process.stdout.write('generate:module-catalog self-test — 5/5 cases passed\n');
+  assert.match(rendered, /## Domain ownership/u);
+  assert.match(
+    rendered,
+    /\| Alpha capability \| `AlphaService` \| `alpha` \| `alpha\/alpha-service\.ts` \|/u
+  );
+  assert.equal(rendered, renderModuleCatalog({ descriptors, edges, ownership }));
+  process.stdout.write('generate:module-catalog self-test — 7/7 cases passed\n');
 }
 
 function main(): void {

--- a/server/scripts/lib/domain-ownership.ts
+++ b/server/scripts/lib/domain-ownership.ts
@@ -1,0 +1,407 @@
+/**
+ * The Domain Ownership Matrix as a checked contract rather than prose.
+ *
+ * The matrix in the root CLAUDE.md tells a stage which service owns a domain. Nothing read it, so
+ * it drifted: `CommandParser` had not been an exported name since the class became
+ * `UnifiedCommandParser`, and `StyleManager` was listed under `styles/` after it moved to
+ * `modules/formatting/`. Both rows still read as authoritative.
+ *
+ * Each owning module now declares its rows in its own `module.yaml` (`owns:`), and this module
+ * compares the two artifacts in BOTH directions — a row with no declaration and a declaration with
+ * no row are equally failures, because the one-directional check is how a matrix keeps a row for a
+ * symbol that no longer exists.
+ *
+ * Parsing and matching here are pure functions over text; the only filesystem work is the
+ * definition scan and `auditOwnership`, which the catalog generator reuses rather than writing a
+ * second scan of its own. The script that owns the CLI stays thin.
+ */
+
+import { readFileSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+
+import {
+  loadSemanticModuleTree,
+  type SemanticModuleDescriptor,
+} from './semantic-module-descriptors.js';
+
+/** One `owns` entry, carried with the descriptor that declared it. */
+export interface OwnershipRecord {
+  readonly capability: string;
+  readonly symbol: string;
+  readonly moduleId: string;
+  /** Descriptor directory relative to `server/src` (`.` for the root descriptor). */
+  readonly modulePath: string;
+  /** Descriptor path relative to the repository root, for problem messages. */
+  readonly descriptorPath: string;
+}
+
+/** One parsed row of the markdown matrix. */
+interface MatrixRow {
+  readonly capability: string;
+  readonly ownerCell: string;
+  readonly text: string;
+}
+
+export interface OwnershipProblem {
+  readonly path: string;
+  readonly message: string;
+}
+
+export interface AuditOwnershipOptions {
+  readonly repoRoot: string;
+  readonly sourceRoot: string;
+  readonly claudeMdPath: string;
+}
+
+export interface OwnershipAudit {
+  readonly records: readonly OwnershipRecord[];
+  /** Symbol -> every file under `server/src` that exports it, relative to `server/src`. */
+  readonly definitions: ReadonlyMap<string, readonly string[]>;
+  readonly problems: readonly OwnershipProblem[];
+}
+
+const MATRIX_HEADING = '## Domain Ownership Matrix';
+const IDENTIFIER_BOUNDARY = '[^A-Za-z0-9_$]';
+
+function normalizeSlashes(value: string): string {
+  return value.split(path.sep).join('/');
+}
+
+function displayPath(repoRoot: string, absolutePath: string): string {
+  return normalizeSlashes(path.relative(repoRoot, absolutePath));
+}
+
+function escapeRegExp(value: string): string {
+  return value.replaceAll(/[.*+?^${}()|[\]\\]/gu, String.raw`\$&`);
+}
+
+function normalizeCapability(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+// ---------------------------------------------------------------------------
+// Declarations
+// ---------------------------------------------------------------------------
+
+export function collectOwnershipRecords(
+  descriptors: readonly SemanticModuleDescriptor[],
+  repoRoot: string
+): OwnershipRecord[] {
+  const records: OwnershipRecord[] = [];
+  for (const descriptor of descriptors) {
+    for (const entry of descriptor.owns ?? []) {
+      records.push({
+        capability: entry.capability,
+        symbol: entry.symbol,
+        moduleId: descriptor.id,
+        modulePath: descriptor.sourcePath,
+        descriptorPath: displayPath(repoRoot, descriptor.descriptorPath),
+      });
+    }
+  }
+  return records;
+}
+
+// ---------------------------------------------------------------------------
+// Definition scan
+// ---------------------------------------------------------------------------
+
+/**
+ * Test files and ambient declarations are excluded: a `.d.ts` re-declares a symbol it does not
+ * define, and a fixture in `tests/` can export the same name without owning anything.
+ */
+function isScannableSource(relativePath: string): boolean {
+  if (!relativePath.endsWith('.ts')) return false;
+  if (relativePath.endsWith('.test.ts') || relativePath.endsWith('.d.ts')) return false;
+  return !relativePath.split('/').includes('tests');
+}
+
+function collectSourceFiles(sourceRoot: string, directory: string, into: string[]): void {
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    const absolute = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      if (!entry.name.startsWith('.')) collectSourceFiles(sourceRoot, absolute, into);
+      continue;
+    }
+    const relative = normalizeSlashes(path.relative(sourceRoot, absolute));
+    if (isScannableSource(relative)) into.push(relative);
+  }
+}
+
+/**
+ * The shape a definition has to take to count: a top-level `export` of the symbol itself. A
+ * re-export gives a symbol a second import path without defining it, so it deliberately does not
+ * match — that is the same distinction `validate:no-crosslayer-reexport` draws.
+ */
+function definitionPattern(symbol: string): RegExp {
+  return new RegExp(
+    `^export (abstract )?(class|interface|function|const|type|enum) ${escapeRegExp(symbol)}\\b`,
+    'mu'
+  );
+}
+
+function definesSymbol(text: string, symbol: string): boolean {
+  return definitionPattern(symbol).test(text);
+}
+
+/**
+ * Symbol -> every scannable file under `sourceRoot` that exports it, relative to `sourceRoot`.
+ *
+ * One pass over the tree for all symbols; each file is read once.
+ */
+export function resolveOwnershipDefinitions(
+  sourceRoot: string,
+  symbols: readonly string[]
+): Map<string, string[]> {
+  const unique = [...new Set(symbols)];
+  const found = new Map<string, string[]>(unique.map((symbol) => [symbol, []]));
+  const files: string[] = [];
+  collectSourceFiles(sourceRoot, sourceRoot, files);
+  for (const relative of files.sort((left, right) => left.localeCompare(right))) {
+    const text = readFileSync(path.join(sourceRoot, relative), 'utf8');
+    for (const symbol of unique) {
+      if (definesSymbol(text, symbol)) found.get(symbol)?.push(relative);
+    }
+  }
+  return found;
+}
+
+// ---------------------------------------------------------------------------
+// Matrix parsing
+// ---------------------------------------------------------------------------
+
+function tableCells(line: string): string[] | null {
+  const trimmed = line.trim();
+  if (!trimmed.startsWith('|') || !trimmed.endsWith('|')) return null;
+  return trimmed
+    .slice(1, -1)
+    .split('|')
+    .map((cell) => cell.trim());
+}
+
+function isSeparatorRow(cells: readonly string[]): boolean {
+  return cells.every((cell) => /^:?-{3,}:?$/u.test(cell));
+}
+
+/**
+ * Rows of the matrix that follows `## Domain Ownership Matrix`, header and separator dropped.
+ *
+ * Rows before the separator are the header, so collection starts there rather than assuming a
+ * particular header text.
+ */
+function parseOwnershipMatrix(markdown: string): MatrixRow[] {
+  const lines = markdown.split('\n');
+  const start = lines.findIndex((line) => line.startsWith(MATRIX_HEADING));
+  if (start < 0) throw new Error(`no "${MATRIX_HEADING}" heading found`);
+
+  const rows: MatrixRow[] = [];
+  let inBody = false;
+  for (const line of lines.slice(start + 1)) {
+    if (line.startsWith('## ')) break;
+    const cells = tableCells(line);
+    if (cells === null) continue;
+    if (isSeparatorRow(cells)) {
+      inBody = true;
+      continue;
+    }
+    if (!inBody) continue;
+    rows.push({ capability: cells[0] ?? '', ownerCell: cells[1] ?? '', text: line.trim() });
+  }
+  if (rows.length === 0) throw new Error(`the ${MATRIX_HEADING} table has no rows`);
+  return rows;
+}
+
+function ownerCellNamesSymbol(ownerCell: string, symbol: string): boolean {
+  const pattern = new RegExp(
+    `(^|${IDENTIFIER_BOUNDARY})${escapeRegExp(symbol)}(${IDENTIFIER_BOUNDARY}|$)`,
+    'u'
+  );
+  return pattern.test(ownerCell);
+}
+
+/** Backticked fragments of the owner cell that look like a path — the ones a reader would follow. */
+function ownerCellPathFragments(ownerCell: string): string[] {
+  return [...ownerCell.matchAll(/`([^`]+)`/gu)]
+    .map((match) => match[1] ?? '')
+    .filter((fragment) => fragment.includes('/'));
+}
+
+// ---------------------------------------------------------------------------
+// Checks
+// ---------------------------------------------------------------------------
+
+/** A. The symbol is exported by exactly one file, and that file lives in the declaring module. */
+function checkDefinition(
+  record: OwnershipRecord,
+  definitions: ReadonlyMap<string, readonly string[]>
+): OwnershipProblem[] {
+  const paths = definitions.get(record.symbol) ?? [];
+  if (paths.length === 0) {
+    return [
+      {
+        path: record.descriptorPath,
+        message: `owns '${record.capability}' names ${record.symbol}, which no file under server/src exports`,
+      },
+    ];
+  }
+  if (paths.length > 1) {
+    return [
+      {
+        path: record.descriptorPath,
+        message: `owns '${record.capability}' names ${record.symbol}, which ${paths.length} files export: ${paths.join(', ')}`,
+      },
+    ];
+  }
+  const definedIn = paths[0] ?? '';
+  const prefix = record.modulePath === '.' ? '' : `${record.modulePath}/`;
+  if (!definedIn.startsWith(prefix)) {
+    return [
+      {
+        path: record.descriptorPath,
+        message: `owns '${record.capability}' names ${record.symbol}, defined outside module '${record.moduleId}' at src/${definedIn}`,
+      },
+    ];
+  }
+  return [];
+}
+
+/** B. One owner per symbol. Two capabilities in ONE descriptor is fine; two descriptors is not. */
+function checkSingleOwner(records: readonly OwnershipRecord[]): OwnershipProblem[] {
+  const owners = new Map<string, string>();
+  const problems: OwnershipProblem[] = [];
+  for (const record of records) {
+    const previous = owners.get(record.symbol);
+    if (previous === undefined) {
+      owners.set(record.symbol, record.descriptorPath);
+      continue;
+    }
+    if (previous !== record.descriptorPath) {
+      problems.push({
+        path: record.descriptorPath,
+        message: `${record.symbol} is already owned by ${previous}; a symbol has one owning module`,
+      });
+    }
+  }
+  return problems;
+}
+
+function checkOwnerCell(
+  row: MatrixRow,
+  record: OwnershipRecord,
+  definitions: ReadonlyMap<string, readonly string[]>,
+  claudeMdPath: string
+): OwnershipProblem[] {
+  const problems: OwnershipProblem[] = [];
+  if (!ownerCellNamesSymbol(row.ownerCell, record.symbol)) {
+    problems.push({
+      path: claudeMdPath,
+      message: `row '${row.text}' does not name ${record.symbol}, declared by ${record.descriptorPath}`,
+    });
+  }
+  const definedIn = (definitions.get(record.symbol) ?? [])[0];
+  if (definedIn === undefined) return problems;
+  for (const fragment of ownerCellPathFragments(row.ownerCell)) {
+    if (!definedIn.includes(fragment)) {
+      problems.push({
+        path: claudeMdPath,
+        message: `row '${row.text}' points at '${fragment}', but ${record.symbol} is defined at src/${definedIn} (declared by ${record.descriptorPath})`,
+      });
+    }
+  }
+  return problems;
+}
+
+/** C, forward: every row has exactly one declaration, and the row's own text agrees with it. */
+function checkRow(
+  row: MatrixRow,
+  records: readonly OwnershipRecord[],
+  definitions: ReadonlyMap<string, readonly string[]>,
+  claudeMdPath: string
+): OwnershipProblem[] {
+  const matches = records.filter(
+    (record) => normalizeCapability(record.capability) === normalizeCapability(row.capability)
+  );
+  if (matches.length === 0) {
+    return [
+      {
+        path: claudeMdPath,
+        message: `row '${row.text}' has no owns entry in any module.yaml`,
+      },
+    ];
+  }
+  if (matches.length > 1) {
+    return [
+      {
+        path: claudeMdPath,
+        message: `row '${row.text}' matches ${matches.length} owns entries: ${matches.map((match) => match.descriptorPath).join(', ')}`,
+      },
+    ];
+  }
+  return checkOwnerCell(row, matches[0] as OwnershipRecord, definitions, claudeMdPath);
+}
+
+/** C, reverse: every declaration has a row. Without this half a module can own a secret domain. */
+function checkDeclaredRowsExist(
+  records: readonly OwnershipRecord[],
+  rows: readonly MatrixRow[],
+  claudeMdPath: string
+): OwnershipProblem[] {
+  const declared = new Set(rows.map((row) => normalizeCapability(row.capability)));
+  return records
+    .filter((record) => !declared.has(normalizeCapability(record.capability)))
+    .map((record) => ({
+      path: record.descriptorPath,
+      message: `owns '${record.capability}' (${record.symbol}) has no row in the Domain Ownership Matrix of ${claudeMdPath}`,
+    }));
+}
+
+function checkOwnership(
+  records: readonly OwnershipRecord[],
+  rows: readonly MatrixRow[],
+  definitions: ReadonlyMap<string, readonly string[]>,
+  claudeMdPath: string
+): OwnershipProblem[] {
+  const problems: OwnershipProblem[] = [];
+  for (const record of records) problems.push(...checkDefinition(record, definitions));
+  problems.push(...checkSingleOwner(records));
+  for (const row of rows) problems.push(...checkRow(row, records, definitions, claudeMdPath));
+  problems.push(...checkDeclaredRowsExist(records, rows, claudeMdPath));
+  return problems;
+}
+
+export function auditOwnership(options: AuditOwnershipOptions): OwnershipAudit {
+  const repoRoot = path.resolve(options.repoRoot);
+  const sourceRoot = path.resolve(options.sourceRoot);
+  const claudeMdPath = path.resolve(options.claudeMdPath);
+  const tree = loadSemanticModuleTree({ repoRoot, sourceRoot });
+  if (tree.problems.length > 0) {
+    return {
+      records: [],
+      definitions: new Map(),
+      problems: tree.problems.map((problem) => ({
+        path: problem.path,
+        message: `descriptor must validate first: ${problem.message}`,
+      })),
+    };
+  }
+
+  const records = collectOwnershipRecords(tree.descriptors, repoRoot);
+  const definitions = resolveOwnershipDefinitions(
+    sourceRoot,
+    records.map((record) => record.symbol)
+  );
+  const rows = parseOwnershipMatrix(readFileSync(claudeMdPath, 'utf8'));
+  const problems = checkOwnership(records, rows, definitions, displayPath(repoRoot, claudeMdPath));
+  return {
+    records,
+    definitions,
+    problems: problems.sort(
+      (left, right) =>
+        left.path.localeCompare(right.path) || left.message.localeCompare(right.message)
+    ),
+  };
+}
+
+export function formatOwnershipProblems(problems: readonly OwnershipProblem[]): string {
+  return problems.map((problem) => `- ${problem.path}: ${problem.message}`).join('\n');
+}

--- a/server/scripts/lib/semantic-module-descriptors.ts
+++ b/server/scripts/lib/semantic-module-descriptors.ts
@@ -17,6 +17,44 @@ const MODULE_KINDS = [
 const MODULE_LIFECYCLES = ['canonical', 'migrating', 'legacy'] as const;
 const MODULE_CHILD_POLICIES = ['semantic', 'internal'] as const;
 
+/**
+ * One row of the Domain Ownership Matrix, declared where the owner lives.
+ *
+ * The matrix in the root CLAUDE.md was prose: two of its fourteen rows named a symbol or a path
+ * that no longer existed. `owns` moves the claim next to the code so
+ * `validate:domain-ownership` can check both directions.
+ */
+const ModuleOwnershipEntrySchema = z
+  .object({
+    capability: z.string().trim().min(1),
+    symbol: z.string().regex(/^[A-Za-z_$][A-Za-z0-9_$]*$/, 'must be a bare identifier'),
+  })
+  .strict();
+
+export type ModuleOwnershipEntry = z.infer<typeof ModuleOwnershipEntrySchema>;
+
+/**
+ * A symbol may own SEVERAL capabilities — `FrameworkManager` owns both framework selection and
+ * framework validity — so only the (symbol, capability) pair has to be unique.
+ */
+function checkOwnershipUniqueness(
+  owns: readonly ModuleOwnershipEntry[] | undefined,
+  context: z.RefinementCtx
+): void {
+  const seen = new Set<string>();
+  for (const [index, entry] of (owns ?? []).entries()) {
+    const key = `${entry.symbol}\u0000${entry.capability}`;
+    if (seen.has(key)) {
+      context.addIssue({
+        code: 'custom',
+        path: ['owns', index],
+        message: `duplicate ownership entry: ${entry.symbol} already owns '${entry.capability}'`,
+      });
+    }
+    seen.add(key);
+  }
+}
+
 export const ModuleDescriptorDocumentSchema = z
   .object({
     schemaVersion: z.literal(1),
@@ -32,9 +70,11 @@ export const ModuleDescriptorDocumentSchema = z
       .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/)
       .optional(),
     removeWhen: z.string().trim().min(1).optional(),
+    owns: z.array(ModuleOwnershipEntrySchema).optional(),
   })
   .strict()
   .superRefine((descriptor, context) => {
+    checkOwnershipUniqueness(descriptor.owns, context);
     const requiresRemoval = descriptor.lifecycle !== 'canonical';
     if (requiresRemoval && descriptor.replacement === undefined) {
       context.addIssue({

--- a/server/scripts/run-validation-suite.js
+++ b/server/scripts/run-validation-suite.js
@@ -123,6 +123,13 @@ export const SUITE = [
       'CHECKED both ways — a semantic parent with an undescribed child fails, and an internal parent with a nested descriptor also fails',
   },
   {
+    script: 'validate:domain-ownership',
+    io: 'read',
+    reads: ['declared'],
+    converse:
+      'CHECKED both ways — a matrix row with no `owns` declaration fails, and an `owns` declaration with no matrix row fails; the row must also name a symbol some file under src/ exports and point at the path it is defined in',
+  },
+  {
     script: 'validate:module-catalog',
     io: 'read',
     reads: ['file', 'spawn'],

--- a/server/scripts/validate-domain-ownership.ts
+++ b/server/scripts/validate-domain-ownership.ts
@@ -1,0 +1,296 @@
+#!/usr/bin/env tsx
+
+/**
+ * The Domain Ownership Matrix in the root CLAUDE.md is a contract, checked both ways.
+ *
+ * Prose that nothing reads drifts silently. Two of the matrix's fourteen rows were already wrong
+ * when this gate was written: `CommandParser` named no exported symbol (the class is
+ * `UnifiedCommandParser`), and `StyleManager` was filed under `styles/` after it moved to
+ * `modules/formatting/`. A stage author following either row lands nowhere, and nothing failed.
+ *
+ * Each owning module declares its rows in its own `module.yaml` (`owns:`). This gate checks:
+ *
+ *   A. every declared symbol is exported by exactly one file, inside the declaring module
+ *   B. no symbol is owned by two modules
+ *   C. every matrix row has one declaration and every declaration has a row — and the row's own
+ *      owner cell names the symbol and points at the path the symbol is actually defined in
+ *
+ * C is the half that a one-directional check omits, and the half the drift lived in.
+ *
+ * MECHANISM: script — relation — compares module.yaml declarations against a markdown table and
+ * against the exporting source file; no linter sees more than one of the three.
+ */
+
+import assert from 'node:assert/strict';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+import {
+  auditOwnership,
+  formatOwnershipProblems,
+  type OwnershipAudit,
+} from './lib/domain-ownership.js';
+
+const SERVER_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const REPO_ROOT = path.resolve(SERVER_ROOT, '..');
+
+interface CliOptions {
+  readonly repoRoot: string;
+  readonly sourceRoot: string;
+  readonly claudeMdPath: string;
+  readonly selfTest: boolean;
+}
+
+function parseArgs(args: readonly string[]): CliOptions {
+  let repoRoot = REPO_ROOT;
+  let sourceRoot = path.join(SERVER_ROOT, 'src');
+  let claudeMdPath: string | null = null;
+  let selfTest = false;
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === '--self-test') {
+      selfTest = true;
+    } else if (arg === '--repo-root') {
+      repoRoot = path.resolve(args[++index] ?? '');
+    } else if (arg === '--source-root') {
+      sourceRoot = path.resolve(args[++index] ?? '');
+    } else if (arg === '--claude-md') {
+      claudeMdPath = path.resolve(args[++index] ?? '');
+    } else {
+      throw new Error(`Unknown option: ${arg}`);
+    }
+  }
+  return {
+    repoRoot,
+    sourceRoot,
+    claudeMdPath: claudeMdPath ?? path.join(repoRoot, 'CLAUDE.md'),
+    selfTest,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Self-test fixture. Positive control first: the valid tree must report nothing, or every
+// assertion below would pass against a gate that reports everything.
+// ---------------------------------------------------------------------------
+
+const ROOT_DESCRIPTOR = `
+schemaVersion: 1
+id: fixture-root
+kind: application
+lifecycle: canonical
+description: Fixture root.
+children: semantic
+`;
+
+const ALPHA_DESCRIPTOR = `
+schemaVersion: 1
+id: fixture-alpha
+kind: domain
+lifecycle: canonical
+description: Fixture alpha.
+children: internal
+owns:
+  - capability: Capability one
+    symbol: AlphaService
+`;
+
+const BETA_DESCRIPTOR = `
+schemaVersion: 1
+id: fixture-beta
+kind: domain
+lifecycle: canonical
+description: Fixture beta.
+children: internal
+`;
+
+const ALPHA_SOURCE = 'export class AlphaService {}\n';
+
+const FIXTURE_CLAUDE_MD = [
+  '# Fixture handbook',
+  '',
+  '## Domain Ownership Matrix (ENFORCED)',
+  '',
+  '**Stages are thin orchestration.**',
+  '',
+  '| If you need... | Owner Service | Stage May Only |',
+  '| --- | --- | --- |',
+  '| Capability one | AlphaService (`alpha/alpha-service.ts`) | Call `alpha.one()` |',
+  '',
+  '## Next section',
+  '',
+].join('\n');
+
+function writeDescriptor(directory: string, body: string): void {
+  mkdirSync(directory, { recursive: true });
+  writeFileSync(path.join(directory, 'module.yaml'), `${body.trim()}\n`, 'utf8');
+}
+
+function writeSource(file: string, body: string): void {
+  mkdirSync(path.dirname(file), { recursive: true });
+  writeFileSync(file, body, 'utf8');
+}
+
+function inspectFixture(mutate?: (_root: string, _source: string) => void): OwnershipAudit {
+  const root = mkdtempSync(path.join(os.tmpdir(), 'domain-ownership-'));
+  const source = path.join(root, 'src');
+  try {
+    writeDescriptor(source, ROOT_DESCRIPTOR);
+    writeDescriptor(path.join(source, 'alpha'), ALPHA_DESCRIPTOR);
+    writeDescriptor(path.join(source, 'beta'), BETA_DESCRIPTOR);
+    writeSource(path.join(source, 'alpha', 'alpha-service.ts'), ALPHA_SOURCE);
+    writeFileSync(path.join(root, 'CLAUDE.md'), FIXTURE_CLAUDE_MD, 'utf8');
+    mutate?.(root, source);
+    return auditOwnership({
+      repoRoot: root,
+      sourceRoot: source,
+      claudeMdPath: path.join(root, 'CLAUDE.md'),
+    });
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+function problemsOf(mutate?: (_root: string, _source: string) => void): string {
+  return formatOwnershipProblems(inspectFixture(mutate).problems);
+}
+
+function withMatrixRow(row: string): string {
+  return FIXTURE_CLAUDE_MD.replace('\n\n## Next section', `\n${row}\n\n## Next section`);
+}
+
+const SELF_TEST_CASES: ReadonlyArray<{ readonly run: () => void }> = [
+  {
+    run: () => {
+      const valid = inspectFixture();
+      assert.equal(formatOwnershipProblems(valid.problems), '');
+      assert.equal(valid.records.length, 1);
+    },
+  },
+  {
+    run: () =>
+      assert.match(
+        problemsOf((_root, source) =>
+          writeSource(path.join(source, 'alpha', 'alpha-service.ts'), 'export class Other {}\n')
+        ),
+        /names AlphaService, which no file under server\/src exports/u
+      ),
+  },
+  {
+    run: () =>
+      assert.match(
+        problemsOf((_root, source) =>
+          writeSource(path.join(source, 'alpha', 'copy.ts'), ALPHA_SOURCE)
+        ),
+        /which 2 files export/u
+      ),
+  },
+  {
+    run: () =>
+      assert.match(
+        problemsOf((_root, source) => {
+          rmSync(path.join(source, 'alpha', 'alpha-service.ts'));
+          writeSource(path.join(source, 'beta', 'alpha-service.ts'), ALPHA_SOURCE);
+        }),
+        /defined outside module 'fixture-alpha' at src\/beta\/alpha-service\.ts/u
+      ),
+  },
+  {
+    run: () =>
+      assert.match(
+        problemsOf((root, source) => {
+          writeDescriptor(
+            path.join(source, 'beta'),
+            `${BETA_DESCRIPTOR}owns:\n  - capability: Capability two\n    symbol: AlphaService\n`
+          );
+          writeFileSync(
+            path.join(root, 'CLAUDE.md'),
+            withMatrixRow('| Capability two | AlphaService | Call `alpha.two()` |'),
+            'utf8'
+          );
+        }),
+        /AlphaService is already owned by src\/alpha\/module\.yaml/u
+      ),
+  },
+  {
+    run: () =>
+      assert.match(
+        problemsOf((root) =>
+          writeFileSync(
+            path.join(root, 'CLAUDE.md'),
+            withMatrixRow('| Capability two | BetaService | Call `beta.two()` |'),
+            'utf8'
+          )
+        ),
+        /has no owns entry in any module\.yaml/u
+      ),
+  },
+  {
+    run: () =>
+      assert.match(
+        problemsOf((_root, source) => {
+          writeDescriptor(
+            path.join(source, 'beta'),
+            `${BETA_DESCRIPTOR}owns:\n  - capability: Capability two\n    symbol: BetaService\n`
+          );
+          writeSource(
+            path.join(source, 'beta', 'beta-service.ts'),
+            'export class BetaService {}\n'
+          );
+        }),
+        /owns 'Capability two' \(BetaService\) has no row in the Domain Ownership Matrix/u
+      ),
+  },
+  {
+    run: () =>
+      assert.match(
+        problemsOf((root) =>
+          writeFileSync(
+            path.join(root, 'CLAUDE.md'),
+            FIXTURE_CLAUDE_MD.replace('alpha/alpha-service.ts', 'gamma/alpha-service.ts'),
+            'utf8'
+          )
+        ),
+        /points at 'gamma\/alpha-service\.ts', but AlphaService is defined at src\/alpha\/alpha-service\.ts/u
+      ),
+  },
+];
+
+function selfTest(): void {
+  for (const testCase of SELF_TEST_CASES) testCase.run();
+  process.stdout.write(
+    `validate:domain-ownership self-test — ${SELF_TEST_CASES.length}/${SELF_TEST_CASES.length} cases passed\n`
+  );
+}
+
+function main(): void {
+  const options = parseArgs(process.argv.slice(2));
+  if (options.selfTest) {
+    selfTest();
+    return;
+  }
+  const audit = auditOwnership(options);
+  if (audit.problems.length > 0) {
+    process.stderr.write(
+      `validate:domain-ownership FAILED — ${audit.problems.length} problem(s)\n${formatOwnershipProblems(audit.problems)}\n`
+    );
+    process.exitCode = 1;
+    return;
+  }
+  const modules = new Set(audit.records.map((record) => record.moduleId));
+  process.stdout.write(
+    `validate:domain-ownership OK — ${audit.records.length} capabilities across ${modules.size} modules\n`
+  );
+}
+
+try {
+  main();
+} catch (error) {
+  process.stderr.write(
+    `validate:domain-ownership FAILED — ${error instanceof Error ? error.message : String(error)}\n`
+  );
+  process.exitCode = 1;
+}

--- a/server/src/engine/execution/module.yaml
+++ b/server/src/engine/execution/module.yaml
@@ -4,3 +4,14 @@ kind: domain
 lifecycle: canonical
 description: Parses commands and coordinates the staged client-guided execution pipeline.
 children: internal
+owns:
+  - capability: Gate enforcement mode
+    symbol: resolveEnforcementMode
+  - capability: Command parsing
+    symbol: UnifiedCommandParser
+  - capability: Step capture
+    symbol: StepCaptureService
+  - capability: Response assembly
+    symbol: ResponseAssembler
+  - capability: Injection decisions
+    symbol: InjectionDecisionService

--- a/server/src/engine/frameworks/module.yaml
+++ b/server/src/engine/frameworks/module.yaml
@@ -4,3 +4,8 @@ kind: domain
 lifecycle: canonical
 description: Loads, validates, selects, and applies reasoning frameworks.
 children: internal
+owns:
+  - capability: Framework selection
+    symbol: FrameworkManager
+  - capability: Framework validity
+    symbol: FrameworkManager

--- a/server/src/engine/gates/module.yaml
+++ b/server/src/engine/gates/module.yaml
@@ -4,3 +4,14 @@ kind: domain
 lifecycle: canonical
 description: Selects, enhances, and evaluates quality-gate guidance.
 children: internal
+owns:
+  - capability: Gate normalization
+    symbol: GateService
+  - capability: Gate enhancement
+    symbol: GateEnhancementService
+  - capability: Gate selection
+    symbol: GateManager
+  - capability: Gate verdict processing
+    symbol: GateVerdictProcessor
+  - capability: Inline gate parsing
+    symbol: InlineGateProcessor

--- a/server/src/modules/formatting/module.yaml
+++ b/server/src/modules/formatting/module.yaml
@@ -5,3 +5,6 @@ lifecycle: canonical
 description: Owns response styles and output formatting behavior.
 children: internal
 publicEntry: index.ts
+owns:
+  - capability: Style resolution
+    symbol: StyleManager

--- a/server/src/modules/prompts/module.yaml
+++ b/server/src/modules/prompts/module.yaml
@@ -5,3 +5,6 @@ lifecycle: canonical
 description: Owns prompt discovery, schema, registry, and lifecycle behavior.
 children: internal
 publicEntry: index.ts
+owns:
+  - capability: Prompt resolution
+    symbol: PromptRegistry


### PR DESCRIPTION
## Summary

After this merges, the Domain Ownership Matrix in `CLAUDE.md` fails validation whenever it disagrees with the module descriptors, in either direction.

- Each owning module declares its capabilities and owner symbols in its `module.yaml` under `owns`.
- A new suite step, `validate:domain-ownership`, checks that every owner symbol is exported exactly once, inside its declaring module, and that every matrix row and every declaration match one another, including the path fragments in each row.
- Two matrix rows that had drifted are corrected: command parsing names `UnifiedCommandParser`, and style resolution points at `modules/formatting/`.
- The generated module catalog gains a Domain ownership section.
- No runtime code changes: nothing under `dist/`, the tool surface, or the published tarball differs.

## Demonstration

**Before** — the validator run against the matrix as it stood on main:

```
validate:domain-ownership FAILED — 2 problem(s)
- CLAUDE.md: row '| Command parsing … CommandParser (`execution/parsers/`) …' does not name UnifiedCommandParser, declared by server/src/engine/execution/module.yaml
- CLAUDE.md: row '| Style resolution … StyleManager (`styles/style-manager.ts`) …' points at 'styles/style-manager.ts', but StyleManager is defined at src/modules/formatting/style-manager.ts
```

**After** — same command on this branch, then with one symbol deliberately misspelled in a descriptor:

```
validate:domain-ownership OK — 14 capabilities across 5 modules

validate:domain-ownership FAILED — 2 problem(s)
- CLAUDE.md: row '| Style resolution …' does not name StyleManagr, declared by server/src/modules/formatting/module.yaml
- server/src/modules/formatting/module.yaml: owns 'Style resolution' names StyleManagr, which no file under server/src exports
```

## How it was verified

| Claim | Probe | Baseline → measured | Mutation that fails it |
| --- | --- | --- | --- |
| The gate sees real drift | `npm run validate:domain-ownership` on the pre-fix `CLAUDE.md` | 2 problems, the two rows above → 0 after the fix | restore either old row |
| The gate can fail on a bad declaration | misspell `StyleManager` in `modules/formatting/module.yaml`, rerun | OK → FAILED, 2 addressed lines | that mutation |
| Fixture cases cover every check | `tsx scripts/validate-domain-ownership.ts --self-test` | 8/8 pass; 7 are must-fail cases | remove any check from the lib |
| The step is wired and observed | `npm run validate:suite-membership` | 54 → 55 steps in SUITE | delete the SUITE entry |
| Runtime is untouched | `npm run build && rg -c "module.yaml\|domain-ownership" dist/index.js` | 0 → 0 matches; `verify:mcp` 18/18 | import the descriptor lib from `src/` |
| Suites unchanged | `test:unit` · `test:integration` · `test:e2e` | 3020 · 805 · 190 pass → same | — |

## Notes for Reviewers

- `server/scripts/lib/domain-ownership.ts` — distrust the definition scan: it matches `export (class|interface|function|const|type|enum) Name` on a line, so a re-export barrel or a `export default` owner would read as undefined. None of the fourteen symbols are shaped that way today; a new one might be.
- `server/scripts/run-validation-suite.js` — the new entry declares `reads: ['declared']` although the lib walks the filesystem. The substrate audit derives that field by following `.js` imports only, so it cannot see work inside a `.ts` lib and rejects the truer value. Same as the sibling `validate:module-descriptors`.
- `CLAUDE.md` — the new command-reference row is wider than the table's padding. Prettier accepts it; re-padding would have touched twenty unrelated rows.

## Still open

- The `@lifecycle canonical` header on 445 source files duplicates the descriptor's lifecycle field and has one reader, a file-size exemption. Removing it is a separate mechanical change.
- The ownership check is sole-definer only. Checking that stages import a capability only from its owner is a second step, waiting on a first sighting.

## README Charter Compliance

Not applicable

<details>
<summary>Appendix — session archive (not review material)</summary>

Additional positive controls run and reverted before commit:

- Duplicate `owns` entry in one descriptor → `validate:module-descriptors FAILED — duplicate ownership entry: StyleManager already owns 'Style resolution' (owns.1)`
- Wrong `reads` value on the SUITE entry → `SUBSTRATE: validate:domain-ownership declares [file] but source contains [declared]` — proves the membership gate observes the new entry rather than passing vacuously.

Verification environment: linked worktree on origin/main, distinct ports for integration and e2e.

</details>
