### PR TITLE
docs(docs): the adoption implementation notes carry plan frontmatter

### DIFF
--- a/plans/adoption-conversion-2026-09-07-implementation-notes.md
+++ b/plans/adoption-conversion-2026-09-07-implementation-notes.md
@@ -1,3 +1,11 @@
+---
+title: "Adoption conversion — implementation notes"
+plan: adoption-conversion-2026-09-07.md
+date: 2026-09-07
+status: active
+tags: [adoption, implementation-notes]
+---
+
 # Adoption Conversion — Implementation Notes
 
 Deviation log for `adoption-conversion-2026-09-07.md`. Session voice; the plan carries the reader


### PR DESCRIPTION
## Summary

After this merges, the full validation suite passes on main again: the adoption implementation notes carry the frontmatter block the plan-retirement check requires.

- One file gains the same four frontmatter fields every other implementation-notes file has.
- No other change. Main's CI has been red since the notes landed this morning, and every PR rebased onto it inherits the failure.

## Demonstration

n/a: docs-only; the observable delta is the suite step below going from failed to passed.

## How it was verified

| Claim | Probe | Baseline → measured | Mutation that fails it |
| --- | --- | --- | --- |
| The retirement check sees the file | `npm run plans:retire:check` inside `server/` | exit 1, naming this file → exit 0 | delete the frontmatter block |

## Notes for Reviewers

- `plans/adoption-conversion-2026-09-07-implementation-notes.md` — only the seven inserted lines; distrust the `status` value if the notes were meant to be already retired.

## Still open

None

## README Charter Compliance

Not applicable
