### PR TITLE
ci(ci): the merge-settings check reports instead of blocking

### DIFF
--- a/.github/workflows/pr-conventions.yml
+++ b/.github/workflows/pr-conventions.yml
@@ -35,6 +35,15 @@ name: PR Conventions
 # main carries a PR-shaped body): the settings are invisible to any file-based gate AND to the
 # workflow token, and the two-register body design depends on them — the collapsed appendix
 # reaches main's history only because the squash body does.
+#
+# That assertion is a WARNING, never a failure, and the reason is structural rather than a
+# tolerance for drift. Its subject is the newest squash commit on main — state no pull request
+# controls, and state that ONLY a merge can change. A required check whose subject is mutable
+# only by the action it gates is a deadlock by construction: the offending merge has already
+# landed, so failing cannot prevent it, and the sole thing that clears the check is the next
+# merge, which the failure blocks. Measured 2026-09-08: merging #265 with an overriding
+# `--body` left #269 MERGEABLE/BLOCKED, and clearing it took an admin bypass. Blocking here
+# buys nothing and costs the repair path.
 
 on:
   pull_request:
@@ -106,22 +115,52 @@ jobs:
               repo: context.repo.repo,
               per_page: 20,
             });
-            const squash = commits.find((c) => /\(#\d+\)$/.test(c.commit.message.split('\n')[0]));
-            if (!squash) {
+            const squashes = commits.filter((c) =>
+              /\(#\d+\)$/.test(c.commit.message.split('\n')[0])
+            );
+            if (squashes.length === 0) {
               core.info('No squash-shaped commit in the last 20 on the default branch.');
               return;
             }
-            const body = squash.commit.message.split('\n').slice(1).join('\n');
-            if (/^## /m.test(body)) {
-              core.info(`Squash ${squash.sha.slice(0, 8)} carries a PR-shaped body — contract holds.`);
+            const carriesBody = (c) =>
+              /^## /m.test(c.commit.message.split('\n').slice(1).join('\n'));
+            const newest = squashes[0];
+            const sha = newest.sha.slice(0, 8);
+            if (carriesBody(newest)) {
+              core.info(`Squash ${sha} carries a PR-shaped body — contract holds.`);
               return;
             }
-            core.setFailed(
-              `Squash commit ${squash.sha.slice(0, 8)} does not carry the PR body — the ` +
-                'squash_merge_commit_message setting has drifted from PR_BODY. Reapply:\n' +
-                '  gh api -X PATCH repos/' + context.repo.owner + '/' + context.repo.repo + ' \\\n' +
-                '    -f squash_merge_commit_title=PR_TITLE -f squash_merge_commit_message=PR_BODY \\\n' +
-                '    -F delete_branch_on_merge=true'
+
+            // Two causes produce an identical bodyless commit, and they need opposite fixes. They
+            // ARE separable from evidence, because they differ in BLAST RADIUS: a drifted setting
+            // strips every squash after it, while `gh pr merge --subject/--body` overrides the
+            // setting for one merge and leaves its neighbours intact. The first version of this
+            // message named only the setting, and sent a reader to re-apply one that was already
+            // correct (measured 2026-09-08, cost real debugging time).
+            const priorWithBody = squashes.slice(1).find(carriesBody);
+            const reapply =
+              '  gh api -X PATCH repos/' + context.repo.owner + '/' + context.repo.repo + ' \\\n' +
+              '    -f squash_merge_commit_title=PR_TITLE -f squash_merge_commit_message=PR_BODY \\\n' +
+              '    -F delete_branch_on_merge=true';
+            const diagnosis = priorWithBody
+              ? `An older squash (${priorWithBody.sha.slice(0, 8)}) DOES carry one, so the ` +
+                'repository setting is probably fine and this was a single overriding merge — ' +
+                'someone passed `--subject`/`--body` to `gh pr merge`, which overrides ' +
+                'squash_merge_commit_message for that merge only. Nothing to repair: merge the ' +
+                'next PR with `gh pr merge <n> --squash` and nothing else, and this clears.\n\n' +
+                'Verify before changing settings:\n' +
+                `  gh api repos/${context.repo.owner}/${context.repo.repo} -q .squash_merge_commit_message`
+              : 'No recent squash carries one either, which is the signature of a drifted ' +
+                'repository setting rather than a one-off merge. Verify, then reapply:\n' +
+                `  gh api repos/${context.repo.owner}/${context.repo.repo} -q .squash_merge_commit_message\n` +
+                reapply;
+
+            core.warning(
+              `Squash commit ${sha} does not carry a PR-shaped body.\n\n${diagnosis}\n\n` +
+                'Reported as a warning, not a failure, on purpose: this check reads main\'s newest ' +
+                'squash, which no pull request controls and only a merge can change. Failing would ' +
+                'block the very merge that clears it while doing nothing about the merge that ' +
+                'caused it — see this workflow\'s header.'
             );
 
       - name: Checkout

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -368,6 +368,18 @@ gh api -X PATCH repos/minipuft/claude-prompts-mcp \
   -F delete_branch_on_merge=true
 ```
 
+**Merge with `gh pr merge <n> --squash` and nothing else.** `--subject` and `--body` override those
+settings for that one merge, so the commit lands without the PR body while the settings themselves
+stay correct — and the workflow's check then reports drift that never happened. Measured 2026-09-08:
+#265 was merged that way, and #269 read the resulting commit and had to be admin-bypassed. Put the
+prose in the PR body before merging, which is where this section already says it belongs. If you
+only need a tidier message, edit the PR body; the squash copies it verbatim.
+
+_That check reports and never blocks, deliberately. Its subject is the newest squash on `main` --
+state no PR controls and only a merge changes -- so failing would block the merge that clears it
+while doing nothing about the merge that caused it. `server/tests/unit/scripts/pr-conventions-merge-settings.test.ts`
+holds that property, and the two-cause diagnosis, against controls._
+
 #### Write for the reader, not the session
 
 Measured 2026-09-01 on #254 and #255: both PRs satisfied the template and were still unreadable at

--- a/server/scripts/validate-documented-options.js
+++ b/server/scripts/validate-documented-options.js
@@ -77,6 +77,8 @@ const NOT_OUR_OPTIONS = new Set([
   '--name-only', // git diff --name-only, used in a generated-artifact check
   '--body', // gh pr create --body; CONTRIBUTING warns it bypasses the PR template
   '--body-file', // gh pr create --body-file; the form CONTRIBUTING tells you to use instead
+  '--squash', // gh pr merge --squash; the only form CONTRIBUTING permits for landing a PR
+  '--subject', // gh pr merge --subject; CONTRIBUTING warns it overrides the PR_BODY squash setting
 ]);
 
 /** Read a file relative to the repo root, empty string when absent. */

--- a/server/tests/unit/scripts/pr-conventions-merge-settings.test.ts
+++ b/server/tests/unit/scripts/pr-conventions-merge-settings.test.ts
@@ -1,0 +1,169 @@
+/**
+ * The merge-settings step in `pr-conventions.yml`, driven against synthetic commit histories.
+ *
+ * WHY THIS EXISTS. That step has been wrong twice, in opposite directions, and neither failure
+ * was reachable by any local gate:
+ *
+ *   · 2026-09-02 (#259) — its first version read the repository's merge settings directly. Those
+ *     fields are admin-only and the workflow token is not admin, so all three read `undefined`
+ *     and the step failed on its own pull request. A probe that cannot observe stood as a gate.
+ *   · 2026-09-08 (#269) — the effect-based replacement was a REQUIRED failing check whose subject
+ *     is the newest squash commit on `main`. No pull request controls that, and only a merge
+ *     changes it, so one overriding merge left every later PR `MERGEABLE / BLOCKED` and clearing
+ *     it took an admin bypass. It also blamed a repository setting that had never drifted.
+ *
+ * Both are logic defects in a script that lives inside YAML, where nothing type-checks it and no
+ * suite runs it. This test extracts the step's script from the workflow file itself — so it cannot
+ * drift from what CI executes — wraps it the way `actions/github-script` does, and drives it with
+ * doubles for `github`, `context` and `core`.
+ *
+ * The load-bearing assertions are the two that encode the failures above: the step must NEVER call
+ * `core.setFailed`, and it must tell a one-off overriding merge apart from a drifted setting. They
+ * differ in blast radius — drift strips every squash after it, an override strips exactly one —
+ * which is the only evidence available to a non-admin observer.
+ *
+ * Classification: Unit (no network, no filesystem writes; reads two repo files)
+ */
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it, beforeAll } from '@jest/globals';
+
+import { parseYamlOrThrow } from '../../../src/shared/utils/yaml/yaml-parser.js';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../..');
+const WORKFLOW = path.join(REPO_ROOT, '.github/workflows/pr-conventions.yml');
+const STEP_NAME = 'Assert the merge-settings contract by its effect';
+
+interface WorkflowFile {
+  jobs: Record<string, { steps: { name?: string; with?: { script?: string } }[] }>;
+}
+
+/** Capture of everything the step reported, so a test can assert on channel as well as content. */
+interface CoreCapture {
+  info: string[];
+  warning: string[];
+  failed: string[];
+}
+
+type StepFn = (
+  github: unknown,
+  context: unknown,
+  core: {
+    info: (_m: string) => void;
+    warning: (_m: string) => void;
+    setFailed: (_m: string) => void;
+  }
+) => Promise<void>;
+
+/**
+ * `actions/github-script` evaluates the script body inside an async function with `github`,
+ * `context` and `core` in scope, which is why the body may `return` at top level. Reproduced here
+ * rather than approximated — a wrapper that differed would test a different program.
+ */
+function loadStep(): StepFn {
+  const workflow = parseYamlOrThrow<WorkflowFile>(readFileSync(WORKFLOW, 'utf8'));
+  const steps = Object.values(workflow.jobs).flatMap((job) => job.steps);
+  const step = steps.find((candidate) => candidate.name === STEP_NAME);
+  if (step?.with?.script === undefined) {
+    throw new Error(
+      `No step named "${STEP_NAME}" with a script in ${WORKFLOW}. If it was renamed, rename it ` +
+        'here too — a silently skipped extraction would make every assertion below vacuous.'
+    );
+  }
+  return new Function(
+    'github',
+    'context',
+    'core',
+    `return (async () => { ${step.with.script} })();`
+  ) as StepFn;
+}
+
+function commit(sha: string, subject: string, body: string) {
+  return { sha, commit: { message: `${subject}\n\n${body}` } };
+}
+
+const SQUASH_SUBJECT = 'feat(scope): a thing (#123)';
+const PR_SHAPED = '## Summary\n\nwhat changed';
+const BARE = 'a hand-written message with no headings';
+
+async function drive(commits: ReturnType<typeof commit>[]): Promise<CoreCapture> {
+  const captured: CoreCapture = { info: [], warning: [], failed: [] };
+  const github = { rest: { repos: { listCommits: async () => ({ data: commits }) } } };
+  await loadStep()(
+    github,
+    { repo: { owner: 'minipuft', repo: 'claude-prompts-mcp' } },
+    {
+      info: (message: string) => captured.info.push(message),
+      warning: (message: string) => captured.warning.push(message),
+      setFailed: (message: string) => captured.failed.push(message),
+    }
+  );
+  return captured;
+}
+
+describe('pr-conventions.yml — merge-settings effect check', () => {
+  beforeAll(() => {
+    // Guards the extraction itself. Every assertion below is about a script this test located by
+    // name inside a YAML file; if that lookup silently returned nothing, they would all pass.
+    expect(() => loadStep()).not.toThrow();
+  });
+
+  it('stays silent when the newest squash carries a PR-shaped body', async () => {
+    const out = await drive([
+      commit('aaaaaaaa', SQUASH_SUBJECT, PR_SHAPED),
+      commit('bbbbbbbb', SQUASH_SUBJECT, PR_SHAPED),
+    ]);
+
+    expect(out.info.join('\n')).toContain('contract holds');
+    expect(out.warning).toHaveLength(0);
+    expect(out.failed).toHaveLength(0);
+  });
+
+  it('never fails the job, whatever it finds — the #269 deadlock', async () => {
+    // The whole point. A required check whose subject only a merge can change must not block, or
+    // it blocks the merge that would clear it. Asserted on the worst input available.
+    const out = await drive([commit('cccccccc', SQUASH_SUBJECT, BARE)]);
+
+    expect(out.failed).toHaveLength(0);
+    expect(out.warning).toHaveLength(1);
+  });
+
+  it('reads a single bare squash among sound ones as an overriding merge, not drift', async () => {
+    const out = await drive([
+      commit('cccccccc', SQUASH_SUBJECT, BARE),
+      commit('dddddddd', SQUASH_SUBJECT, PR_SHAPED),
+    ]);
+
+    const message = out.warning.join('\n');
+    expect(message).toContain('single overriding merge');
+    expect(message).toContain('dddddddd');
+    // The converse matters as much: this is the branch that must NOT send a reader to re-apply a
+    // setting that is already correct, which is exactly what cost debugging time on 2026-09-08.
+    expect(message).not.toContain('drifted repository setting');
+  });
+
+  it('reads an unbroken run of bare squashes as a drifted setting, and names the fix', async () => {
+    const out = await drive([
+      commit('eeeeeeee', SQUASH_SUBJECT, BARE),
+      commit('ffffffff', SQUASH_SUBJECT, BARE),
+    ]);
+
+    const message = out.warning.join('\n');
+    expect(message).toContain('drifted repository setting');
+    expect(message).toContain('-f squash_merge_commit_message=PR_BODY');
+    expect(message).not.toContain('single overriding merge');
+  });
+
+  it('says nothing when no squash-shaped commit is in range', async () => {
+    // A commit with no `(#n)` suffix is not a squash merge. Reporting on it would be a finding
+    // about nothing — the observer has simply not seen the artifact it judges.
+    const out = await drive([commit('11111111', 'feat(scope): direct commit', PR_SHAPED)]);
+
+    expect(out.info.join('\n')).toContain('No squash-shaped commit');
+    expect(out.warning).toHaveLength(0);
+    expect(out.failed).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

The `PR Conventions` job carries a step asserting that the newest squash commit on `main` carries a PR-shaped body. It was a required *failing* check, and that made it a deadlock.

Its subject is state **no pull request controls** and **only a merge changes**. So a bad merge lands, every subsequent PR turns red for a defect it did not introduce, and the sole thing that clears the check is the next merge — which the failure blocks. Failing cannot prevent the damage, only the repair.

Measured 2026-09-08: #265 was merged with an overriding `--body`, #269 went `MERGEABLE / BLOCKED` within minutes, and clearing it took an admin bypass.

Two changes:

- **The step warns instead of failing.** The body and title checks in the same job still block — they read the PR's own content, which the author controls. Only the retrospective one moved.
- **The message names the right cause.** Two causes produce an identical bodyless commit and need opposite fixes: a drifted repository setting, or `gh pr merge --subject/--body` overriding a correct one. Only the first was named, so it told a reader to re-apply a setting that had never moved. They are separable by blast radius — drift strips *every* later squash, an override strips *exactly one* — and the step now reports which it is seeing.

`CONTRIBUTING.md` gains the prevention half: merge with `gh pr merge <n> --squash` and nothing else.

## Demonstration

Same input, before and after:

```
BEFORE  ✗ error  Squash commit 320d3ce6 does not carry the PR body — the
                 squash_merge_commit_message setting has drifted from PR_BODY. Reapply:
                   gh api -X PATCH repos/minipuft/claude-prompts-mcp ...

        (the setting had not drifted; it read PR_BODY throughout. The job failed,
         and PR #269 could not merge.)

AFTER   ⚠ warning  Squash commit 320d3ce6 does not carry a PR-shaped body.

                   An older squash (f76f621d) DOES carry one, so the repository setting
                   is probably fine and this was a single overriding merge — someone
                   passed `--subject`/`--body` to `gh pr merge` ... Nothing to repair:
                   merge the next PR with `gh pr merge <n> --squash` and nothing else,
                   and this clears.

        (the job passes; the body and title checks still gate it)
```

## How it was verified

`server/tests/unit/scripts/pr-conventions-merge-settings.test.ts` extracts the step's script **from the workflow file itself**, wraps it the way `actions/github-script` does, and drives it with doubles. Extracting rather than copying is deliberate: a copy would drift from what CI runs, and this step has already been wrong twice without any local gate noticing.

| Claim | Probe | Result | Mutation that fails it |
| --- | --- | --- | --- |
| A sound history stays silent | newest squash carries `## ` | `info`, no warning | — |
| **Never fails the job, on any input** | worst case: single bare squash | `setFailed` never called | Restore `core.setFailed` → this test fails |
| One bare squash among sound ones reads as an override | bare newest, older sound | names the override, cites the older sha | Drop the blast-radius branch → it reports drift instead |
| An unbroken run of bare squashes reads as drift | all bare | names drift, prints the reapply command | same |
| No squash-shaped commit → says nothing | commit without `(#n)` | `info`, no warning | — |
| The extraction itself is not vacuous | `beforeAll` asserts the step is found by name | throws if renamed | Rename the step → every test errors rather than passing green |
| Whole contract | `validate:all`; `test:all` | 58/58; unit 3041, integration 807, e2e 190 | — |

Mutation-verified: restoring `core.setFailed` fails 3 of the 5 cases, including the load-bearing one.

## Notes for Reviewers

- **This reduces enforcement, and that is the point.** The argument is not that drift matters less — it is that this check is *retrospective*. It observes after the merge, so blocking buys no prevention and costs the repair path. The detection is unchanged and still fires on every PR until cleared.
- **Reading the settings directly is not available**, and was already tried. The workflow `GITHUB_TOKEN` is not admin, so those fields read `undefined` — probed 2026-09-02 on #259, where the first version of this step failed on its own PR. That is why the check asserts an effect at all, and why the fix could not be "block on the declaration instead".
- **The generalizable rule, now in the workflow header:** an effect check may block only if its subject is reachable without the action it gates. Otherwise assert the effect as a warning.
- **`--squash` and `--subject` were added to `NOT_OUR_OPTIONS`** in `validate-documented-options.js`. That gate correctly flagged the new CONTRIBUTING text — they are `gh` flags, not ours — and it names the exemption as its own remedy.
- **A residual worth knowing:** if the repository setting genuinely drifts, this now warns rather than blocks, so it depends on someone reading CI output. Restoring a hard failure would need an admin-token observer that can read the setting directly — a secret, and a decision I did not take.
